### PR TITLE
Extended specs template validate

### DIFF
--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -144,10 +144,20 @@ flowchart TD
     I -->|no| J{isBinary?}
     J -->|yes| Copy2[copy verbatim]
     J -->|no| K[render content as template]
-    K --> L{whitespace-only result?}
+    K --> KE{parse or execution error?}
+    KE -->|yes| Warn["append RenderWarning, copy verbatim"]
+    KE -->|no| L{whitespace-only result?}
     L -->|yes| Skip4[skip — do not create file]
     L -->|no| Write[write to dest]
 ```
+
+If any `RenderWarning` entries are present after `Execute` returns:
+
+- **`template use`** reports each affected file via `Output.Warn` and suggests running
+  `specs template validate <name>` to diagnose the root cause.
+- **`template validate`** reports each affected file, includes them in the exit code
+  (`ValidateRender = 4`), and always runs at debug log level so no diagnostic output
+  is suppressed.
 
 ### Binary Detection
 
@@ -294,18 +304,28 @@ display format for the `list` command.
 
 ## Validation (`specs template validate`)
 
-`Template.Validate()` inspects the template for two categories of issues:
+`specs template validate` always runs at debug log level so no diagnostic output is suppressed.
+It calls `Execute` on a temporary directory first to catch render errors, then calls
+`Template.Validate()` for static analysis.
 
-| Issue kind | Meaning |
-|---|---|
-| `unknown_variable` | A name used in a template file or path is **not defined** in `project.yml` (neither variable nor computed). Reports the file path where the reference was found. |
-| `unused_variable` | A variable **defined** in the user input section is never referenced in any template file, path expression, or computed expression. |
-| `unused_computed` | A computed value **defined** under `computed:` is never referenced anywhere. |
+Three categories of issues are reported:
 
-`unknown_variable` issues are errors — the template will fail to render.
-`unused_*` issues are warnings — they indicate dead schema entries.
+| Issue kind | Source | Meaning |
+|---|---|---|
+| `render_error` | `Execute()` | A file could not be rendered (parse or execution error) and was copied verbatim. |
+| `unknown_variable` | `Validate()` | A name used in a template file or path is **not defined** in `project.yaml`. |
+| `unused_variable` | `Validate()` | A variable **defined** in the user input section is never referenced anywhere. |
+| `unused_computed` | `Validate()` | A computed value **defined** under `computed:` is never referenced anywhere. |
 
-`specs template validate` exits non-zero if any `unknown_variable` issues are found.
+Exit codes are a bitmask — multiple conditions combine additively:
+
+| Bit | Constant | Value | Condition |
+|-----|----------|-------|-----------|
+| 2 | `ValidateRender` | 4 | Any `render_error` — file copied verbatim due to parse or execution error |
+| 1 | `ValidateUnknown` | 2 | Any `unknown_variable` |
+| 0 | `ValidateUnused` | 1 | Any `unused_*` (only with `--strict`) |
+
+`specs template validate` exits 0 only when there are no render errors and no unknown variables.
 
 ---
 

--- a/pkg/cmd/template_use.go
+++ b/pkg/cmd/template_use.go
@@ -129,6 +129,13 @@ func (a *App) executeTemplate(templateRoot, targetDir string, opts executeOpts) 
 		return err
 	}
 
+	if len(tmpl.Warnings) > 0 {
+		for _, w := range tmpl.Warnings {
+			a.Output.Warn("%s was copied verbatim due to a render error: %v", w.Path, w.Err)
+		}
+		a.Output.Warn("run 'specs template validate %s' to see all issues", filepath.Base(templateRoot))
+	}
+
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return err
 	}

--- a/pkg/cmd/template_validate.go
+++ b/pkg/cmd/template_validate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -20,6 +21,8 @@ func newTemplateValidateCmd(app *App) *cobra.Command {
 		Short: "Validate a template directory",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			app.level.Set(slog.LevelDebug)
+
 			templateRoot := args[0]
 
 			templateDir := filepath.Join(templateRoot, specs.TemplateDirFile)
@@ -42,6 +45,10 @@ func newTemplateValidateCmd(app *App) *cobra.Command {
 				return fmt.Errorf("template render error: %w", err)
 			}
 
+			for _, w := range tmpl.Warnings {
+				app.Output.Warn("render error in %s: %v", w.Path, w.Err)
+			}
+
 			issues, err := tmpl.Validate()
 			if err != nil {
 				return fmt.Errorf("validation error: %w", err)
@@ -59,6 +66,9 @@ func newTemplateValidateCmd(app *App) *cobra.Command {
 			}
 
 			code := 0
+			if len(tmpl.Warnings) > 0 {
+				code |= exit.ValidateRender
+			}
 			if pkgtemplate.HasUnknown(issues) {
 				code |= exit.ValidateUnknown
 			}
@@ -69,9 +79,7 @@ func newTemplateValidateCmd(app *App) *cobra.Command {
 				return &exit.ExitError{Code: code}
 			}
 
-			if len(issues) == 0 {
-				app.Output.Info("template is valid")
-			}
+			app.Output.Info("template is valid")
 			return nil
 		},
 	}

--- a/pkg/cmd/template_validate_test.go
+++ b/pkg/cmd/template_validate_test.go
@@ -103,7 +103,8 @@ func TestValidate_UnusedComputed(t *testing.T) {
 	}
 }
 
-// TestValidate_UnknownVariable: warning printed, exit 2.
+// TestValidate_UnknownVariable: warning printed, exit ValidateRender|ValidateUnknown.
+// An unknown variable causes both a render execution error (missingkey=error) and a static analysis hit.
 func TestValidate_UnknownVariable(t *testing.T) {
 	withTempRegistry(t)
 	src := makeValidateTemplate(t,
@@ -112,8 +113,9 @@ func TestValidate_UnknownVariable(t *testing.T) {
 	)
 
 	out, err := executeCmd("template", "validate", src)
-	if code := validateExitCode(err); code != exit.ValidateUnknown {
-		t.Errorf("expected exit %d, got %d (err=%v)", exit.ValidateUnknown, code, err)
+	const wantCode = exit.ValidateRender | exit.ValidateUnknown
+	if code := validateExitCode(err); code != wantCode {
+		t.Errorf("expected exit %d, got %d (err=%v)", wantCode, code, err)
 	}
 	if !strings.Contains(out, "AppName") {
 		t.Errorf("expected warning about AppName, got: %q", out)
@@ -137,7 +139,7 @@ func TestValidate_StrictUnusedVariable(t *testing.T) {
 	}
 }
 
-// TestValidate_StrictUnusedAndUnknown: --strict with both → exit 3 (bitmask 1|2).
+// TestValidate_StrictUnusedAndUnknown: --strict with both → exit ValidateRender|ValidateUnknown|ValidateUnused.
 func TestValidate_StrictUnusedAndUnknown(t *testing.T) {
 	withTempRegistry(t)
 	src := makeValidateTemplate(t,
@@ -146,7 +148,7 @@ func TestValidate_StrictUnusedAndUnknown(t *testing.T) {
 	)
 
 	_, err := executeCmd("template", "validate", "--strict", src)
-	const wantCode = exit.ValidateUnused | exit.ValidateUnknown // 3
+	const wantCode = exit.ValidateRender | exit.ValidateUnused | exit.ValidateUnknown
 	if code := validateExitCode(err); code != wantCode {
 		t.Errorf("expected exit %d, got %d (err=%v)", wantCode, code, err)
 	}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -43,6 +43,13 @@ var ignoredFiles = map[string]bool{
 	"Thumbs.db": true,
 }
 
+// RenderWarning records a non-fatal issue encountered while rendering a template file.
+// The file is still written to the destination as a verbatim copy.
+type RenderWarning struct {
+	Path string // template-relative path of the affected file
+	Err  error
+}
+
 // Template holds everything needed to execute a boilr template.
 type Template struct {
 	Root         string                 // path to the template root (contains project.yaml + template/)
@@ -51,6 +58,7 @@ type Template struct {
 	Conditionals Conditionals           // varName → Cond; absent means always prompt
 	Referenced   map[string]bool        // schema variables referenced in template files or computed expressions
 	Metadata     *Metadata              // nil if __metadata.json is absent
+	Warnings     []RenderWarning        // non-fatal render issues collected during Execute
 	cfg          Config
 	logger       *slog.Logger
 	funcMap      texttemplate.FuncMap
@@ -186,7 +194,7 @@ func (t *Template) Execute(targetDir string) error {
 		if t.verbatim.Matches(relForward) || isBinary(srcPath) {
 			return copyFile(srcPath, destPath)
 		}
-		return t.renderFile(srcPath, destPath, ctx)
+		return t.renderFile(srcPath, destPath, relForward, ctx)
 	})
 }
 
@@ -204,9 +212,10 @@ func (t *Template) renderName(name string, ctx map[string]any) (string, error) {
 	return buf.String(), nil
 }
 
-// renderFile renders a text file's content using [[ ]]  delimiters.
+// renderFile renders a text file's content using the configured delimiters.
 // If the rendered content is whitespace-only, the destination file is not created.
-func (t *Template) renderFile(srcPath, destPath string, ctx map[string]any) error {
+// Parse or execution errors are recorded as RenderWarnings and the file is copied verbatim.
+func (t *Template) renderFile(srcPath, destPath, rel string, ctx map[string]any) error {
 	data, err := os.ReadFile(srcPath)
 	if err != nil {
 		return err
@@ -219,13 +228,13 @@ func (t *Template) renderFile(srcPath, destPath string, ctx map[string]any) erro
 		Option("missingkey=error").
 		Parse(string(data))
 	if err != nil {
-		t.logger.Debug("template parse error, copying verbatim", "path", srcPath, "error", err)
+		t.Warnings = append(t.Warnings, RenderWarning{Path: rel, Err: err})
 		return copyFile(srcPath, destPath)
 	}
 
 	var buf strings.Builder
 	if err := tmpl.Execute(&buf, ctx); err != nil {
-		t.logger.Warn("missing variable in template", "path", srcPath, "error", err)
+		t.Warnings = append(t.Warnings, RenderWarning{Path: rel, Err: err})
 		return copyFile(srcPath, destPath)
 	}
 

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -310,6 +310,38 @@ func TestGet_InvalidDelimiters_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestExecute_ParseError_CopiesVerbatimAndWarns(t *testing.T) {
+	// A template file that calls an undefined function triggers a parse error.
+	// Execute must succeed (verbatim copy), and the warning must be recorded on tmpl.Warnings.
+	yaml := "Name: test\n__delimiters:\n  left: \"[[\"\n  right: \"]]\"\n"
+	original := []byte("[[ .Name | undefinedFunc ]]")
+	root := buildTemplate(t, yaml, map[string][]byte{
+		"compose.yml": original,
+	})
+
+	tmpl, err := pkgtemplate.Get(root, pkgtemplate.Config{}, discardLogger())
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	target := t.TempDir()
+	if err := tmpl.Execute(target); err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+
+	if len(tmpl.Warnings) == 0 {
+		t.Fatal("expected at least one RenderWarning, got none")
+	}
+	if tmpl.Warnings[0].Path != "compose.yml" {
+		t.Errorf("warning path = %q, want %q", tmpl.Warnings[0].Path, "compose.yml")
+	}
+
+	got := readFile(t, target, "compose.yml")
+	if got != string(original) {
+		t.Errorf("compose.yml = %q, want verbatim copy %q", got, string(original))
+	}
+}
+
 func TestGet_CustomDelimiters_ConditionalFilename(t *testing.T) {
 	// Custom delimiters affect filename templates too.
 	yaml := "UseX: true\n__delimiters:\n  left: \"[[\"\n  right: \"]]\"\n"

--- a/pkg/util/exit/exit.go
+++ b/pkg/util/exit/exit.go
@@ -9,6 +9,7 @@ const (
 	// Bitmask exit codes for validate. Multiple conditions combine additively.
 	ValidateUnused  = 1 // bit 0: unused variable/computed value (--strict only)
 	ValidateUnknown = 2 // bit 1: unknown variable referenced in a template file
+	ValidateRender  = 4 // bit 2: file could not be rendered (parse or execution error)
 )
 
 // ExitError is a silent error that carries a specific exit code. main.go uses


### PR DESCRIPTION
More information is provided to the users when running the validate command. When there are any render issues the users gets a warning to run the validate command for more info