### PR TITLE
Use go fix tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Fix (diff mode)
+        continue-on-error: true
+        run: go fix -diff ./...
+
       - name: Test
         run: go test -race -count=1 ./...
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -44,9 +44,7 @@ tasks:
       SPECS_VERSION:
         sh: git describe --tags --always --dirty="-dev" 2>/dev/null || echo "dev"
     cmds:
-      - task: dc:run:go-builder
-        vars:
-          SUB_CMD: go vet
+      - task: vet
       - >-
         docker buildx bake --file compose.yml
         --set "go-binary.output=type=local,dest=."
@@ -55,15 +53,29 @@ tasks:
         --set "go-binary.args.SPECS_VERSION={{.SPECS_VERSION}}"
         go-binary
 
-  test:
-    desc: Run go tests
+  vet:
+    desc: Run go vet
     cmds:
       - task: dc:run:go-builder
         vars:
-          SUB_CMD: "go test ./..."
+          SUB_CMD: go vet
 
-  docker:test:
-    desc: Run go tests (including integration tests) inside the Docker container
+  fix:
+    desc: Run go fix
+    cmds:
+      - task: dc:run:go-builder
+        vars:
+          SUB_CMD: "go fix ./..."
+
+  fix:diff:
+    desc: Run go fix in diff mode
+    cmds:
+      - task: dc:run:go-builder
+        vars:
+          SUB_CMD: "go fix -diff ./..."
+
+  test:
+    desc: Run go tests
     cmds:
       - task: dc:run:go-builder
         vars:

--- a/pkg/cmd/template_use_test.go
+++ b/pkg/cmd/template_use_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/specsnl/specs-cli/pkg/specs"
@@ -378,11 +379,12 @@ func makeTemplateWithSelectVar(t *testing.T, varName string, options []string) s
 	if err := os.MkdirAll(tmplDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	project := varName + ":\n"
+	var project strings.Builder
+	project.WriteString(varName + ":\n")
 	for _, opt := range options {
-		project += "  - " + opt + "\n"
+		project.WriteString("  - " + opt + "\n")
 	}
-	if err := os.WriteFile(filepath.Join(dir, specs.ProjectYAMLFile), []byte(project), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, specs.ProjectYAMLFile), []byte(project.String()), 0644); err != nil {
 		t.Fatal(err)
 	}
 	content := "selected {{." + varName + "}}"

--- a/pkg/host/source.go
+++ b/pkg/host/source.go
@@ -69,13 +69,13 @@ func parseGitHub(input string) (*Source, error) {
 	parts := strings.SplitN(rest, ":", 2)
 
 	repoPart := parts[0]
-	slashIdx := strings.Index(repoPart, "/")
-	if slashIdx < 0 {
+	before, after, ok := strings.Cut(repoPart, "/")
+	if !ok {
 		return nil, fmt.Errorf("invalid github source: missing owner/repo separator in %q", input)
 	}
 
-	owner := repoPart[:slashIdx]
-	repo := repoPart[slashIdx+1:]
+	owner := before
+	repo := after
 
 	if strings.Contains(repo, "/") {
 		return nil, fmt.Errorf("invalid github source: too many path segments in %q", input)
@@ -189,7 +189,7 @@ func validateScpPath(path, input string) error {
 
 func countNonEmptySegments(path string) int {
 	n := 0
-	for _, seg := range strings.Split(path, "/") {
+	for seg := range strings.SplitSeq(path, "/") {
 		if seg != "" {
 			n++
 		}

--- a/pkg/util/git/git.go
+++ b/pkg/util/git/git.go
@@ -184,8 +184,8 @@ func isSSHURL(url string) bool {
 
 // sshUser extracts the username from an SSH URL. Defaults to "git".
 func sshUser(url string) string {
-	if strings.HasPrefix(url, "ssh://") {
-		rest := strings.TrimPrefix(url, "ssh://")
+	if after, ok := strings.CutPrefix(url, "ssh://"); ok {
+		rest := after
 		if at := strings.Index(rest, "@"); at > 0 {
 			return rest[:at]
 		}

--- a/pkg/util/git/git.go
+++ b/pkg/util/git/git.go
@@ -185,9 +185,8 @@ func isSSHURL(url string) bool {
 // sshUser extracts the username from an SSH URL. Defaults to "git".
 func sshUser(url string) string {
 	if after, ok := strings.CutPrefix(url, "ssh://"); ok {
-		rest := after
-		if at := strings.Index(rest, "@"); at > 0 {
-			return rest[:at]
+		if at := strings.Index(after, "@"); at > 0 {
+			return after[:at]
 		}
 	} else {
 		if at := strings.Index(url, "@"); at > 0 {

--- a/pkg/util/values/values.go
+++ b/pkg/util/values/values.go
@@ -3,6 +3,7 @@ package values
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,11 +44,7 @@ func ParseArg(arg string) (key, value string, err error) {
 // Merge applies overrides on top of base, returning a new map.
 func Merge(base, overrides map[string]any) map[string]any {
 	result := make(map[string]any, len(base))
-	for k, v := range base {
-		result[k] = v
-	}
-	for k, v := range overrides {
-		result[k] = v
-	}
+	maps.Copy(result, base)
+	maps.Copy(result, overrides)
 	return result
 }


### PR DESCRIPTION
Applied `go fix` across the codebase to replace deprecated stdlib patterns with their modern equivalents (`strings.Cut`, `strings.CutPrefix`, `strings.SplitSeq`, `maps.Copy`, `strings.Builder`)
- Added a non-blocking `go fix -diff` step to CI (`continue-on-error: true`) so any future regressions are visible in the build output without blocking merges
- Extracted `go vet` into its own `vet` Taskfile task (reused by `build`) and added `fix` / `fix:diff` tasks for local use