### PR TITLE
#51: Implement structured logging for observability

### DIFF
--- a/docs/content/docs/architecture/overview.md
+++ b/docs/content/docs/architecture/overview.md
@@ -244,6 +244,41 @@ flowchart TD
 
 ---
 
+## Logging
+
+`slog` is used throughout the codebase for structured logging. The logger is configured via the `--debug`
+and `--output` flags in `pkg/cmd/root.go`:
+
+- `--debug` raises the log level from `Info` to `Debug`, producing detailed diagnostic output.
+- `--output=json` switches both the slog handler and the output writer to JSON mode, emitting
+  NDJSON log lines to stderr (distinct from the stdout NDJSON output for commands like `specs template ls`).
+
+When both flags are used together (`--debug --output=json`), the slog JSON handler writes structured
+logs to stderr while the command output goes to stdout, making it easy to separate diagnostics from
+command results in scripts and CI pipelines.
+
+### Log attribute conventions
+
+Consistent attribute keys are used across the codebase for correlation:
+
+| Attribute | Description |
+|-----------|-------------|
+| `template_root` | Path to the template root directory |
+| `target_dir` | Destination directory for rendered output |
+| `path` | File or directory path being processed |
+| `dest` | Destination path for a rendered file |
+| `repo` | Git repository URL |
+| `branch` | Git branch or tag reference |
+| `commit` | Git commit hash |
+| `version` | Template or git version string |
+| `key` | Context variable key |
+| `source` | Origin of a value: `default`, `prompt`, `values_file`, `arg_flag`, `computed` |
+| `trigger` | Hook trigger: `pre-use` or `post-use` |
+| `error` | Underlying error (when available) |
+
+Key events are logged at `Info` level (e.g., template execution summary with rendered/verbatim/skipped counts),
+while detailed diagnostic information (per-file decisions, per-key resolution, hook invocations) is at `Debug` level.
+
 ## Error Handling (`pkg/specs/errors.go`)
 
 Sentinel errors are declared in `pkg/specs/errors.go` and should always be wrapped with `%w`

--- a/pkg/cmd/template_list.go
+++ b/pkg/cmd/template_list.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/spf13/cobra"
 	"github.com/specsnl/specs-cli/pkg/specs"
 	pkgtemplate "github.com/specsnl/specs-cli/pkg/template"
 	pkggit "github.com/specsnl/specs-cli/pkg/util/git"
+	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -43,9 +43,11 @@ func newTemplateListCmd(app *App) *cobra.Command {
 				name := e.Name()
 				root := specs.TemplatePath(name)
 				meta, _ := pkgtemplate.LoadMetadata(root)
+				app.Logger.Debug("loaded template entry", "name", name, "has_metadata", meta != nil)
 				var status *pkgtemplate.TemplateStatus
 				if meta != nil && meta.Repository != "" && meta.Branch != "" {
 					status, _ = pkgtemplate.LoadStatus(root)
+					app.Logger.Debug("loaded template status", "name", name, "has_status", status != nil)
 				}
 				tmplEntries = append(tmplEntries, templateEntry{name: name, meta: meta, status: status})
 			}
@@ -74,14 +76,19 @@ func newTemplateListCmd(app *App) *cobra.Command {
 					checkCtx, cancelCheck := context.WithTimeout(egCtx, app.checkTimeout)
 					defer cancelCheck()
 					root := specs.TemplatePath(name)
-					result, _ := app.checkRemoteFn(checkCtx, root, repo, branch)
+					result, err := app.checkRemoteFn(checkCtx, root, repo, branch)
+					if err != nil {
+						app.Logger.Debug("remote check returned unexpected error", "name", name, "repo", repo, "branch", branch, "error", err)
+					}
 					newStatus := &pkgtemplate.TemplateStatus{
 						CheckedAt:     pkgtemplate.JSONTime{Time: time.Now().UTC()},
 						IsUpToDate:    result.IsUpToDate,
 						LatestVersion: result.LatestVersion,
 						ErrorKind:     result.ErrorKind,
 					}
-					_ = pkgtemplate.SaveStatus(root, newStatus)
+					if saveErr := pkgtemplate.SaveStatus(root, newStatus); saveErr != nil {
+						app.Logger.Debug("failed to save template status", "name", name, "error", saveErr)
+					}
 					mu.Lock()
 					tmplEntries[i].status = newStatus
 					if result.ErrorKind == pkggit.CheckErrorNetwork {
@@ -154,4 +161,3 @@ func statusLabel(status *pkgtemplate.TemplateStatus, hasRemote bool) string {
 	}
 	return "update available"
 }
-

--- a/pkg/cmd/template_use.go
+++ b/pkg/cmd/template_use.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -77,13 +78,18 @@ func (a *App) executeTemplate(templateRoot, targetDir string, opts executeOpts) 
 	if err != nil {
 		return err
 	}
-	h, err := hooks.Load(templateRoot, rawConfig, a.HookEnvPrefix)
+	h, err := hooks.Load(templateRoot, rawConfig, a.HookEnvPrefix, a.Logger)
 	if err != nil {
 		return err
 	}
 
 	ctx := tmpl.Context
 	provided := make(map[string]bool)
+
+	// Log initial context keys
+	for k := range tmpl.Context {
+		a.Logger.Debug("context key from schema", "key", k, "source", "default")
+	}
 
 	if opts.valuesFile != "" {
 		fileVals, err := values.LoadFile(opts.valuesFile)
@@ -92,6 +98,7 @@ func (a *App) executeTemplate(templateRoot, targetDir string, opts executeOpts) 
 		}
 		for k := range fileVals {
 			provided[k] = true
+			a.Logger.Debug("context key from values file", "key", k, "source", "values_file")
 		}
 		ctx = values.Merge(ctx, fileVals)
 	}
@@ -103,16 +110,23 @@ func (a *App) executeTemplate(templateRoot, targetDir string, opts executeOpts) 
 		}
 		ctx[k] = v
 		provided[k] = true
+		a.Logger.Debug("context key from arg flag", "key", k, "value", v, "source", "arg_flag")
 	}
 
 	if !opts.useDefaults {
-		if err := promptContext(ctx, tmpl.Context, tmpl.Conditionals, tmpl.Referenced, provided); err != nil {
+		if err := promptContext(ctx, tmpl.Context, tmpl.Conditionals, tmpl.Referenced, provided, a.Logger); err != nil {
 			return err
 		}
 	} else {
 		resolveSelectDefaults(ctx)
+		for k := range ctx {
+			if !provided[k] {
+				a.Logger.Debug("context key using default", "key", k, "source", "default")
+			}
+		}
 	}
 
+	a.Logger.Debug("applying computed values", "count", len(tmpl.ComputedDefs))
 	ctx, err = pkgtemplate.ApplyComputed(ctx, tmpl.ComputedDefs, tmpl.FuncMap(), tmpl.Delims())
 	if err != nil {
 		return err
@@ -218,11 +232,12 @@ func (a *App) confirmRemoteHooks(h *hooks.Hooks, ctx map[string]any, tmpl *pkgte
 // now-final ctx, and prompts those that are needed. This correctly handles
 // nested eq/ne gates where the gate variable is itself conditional.
 func promptContext(
-	ctx        map[string]any,
-	schema     map[string]any,
-	conds      pkgtemplate.Conditionals,
+	ctx map[string]any,
+	schema map[string]any,
+	conds pkgtemplate.Conditionals,
 	referenced map[string]bool,
-	provided   map[string]bool,
+	provided map[string]bool,
+	logger *slog.Logger,
 ) error {
 	schemaKeys := make(map[string]bool, len(schema))
 	for k := range schema {
@@ -243,8 +258,9 @@ func promptContext(
 		}
 	}
 
+	logger.Debug("starting prompt pass 1 (always-needed variables)", "count", len(alwaysKeys))
 	// Pass 1: always-needed variables.
-	if err := runPromptPass(ctx, schema, alwaysKeys, provided); err != nil {
+	if err := runPromptPass(ctx, schema, alwaysKeys, provided, logger); err != nil {
 		return err
 	}
 
@@ -252,12 +268,14 @@ func promptContext(
 	resolved := make(map[string]bool, len(alwaysKeys)+len(provided))
 	for _, k := range alwaysKeys {
 		resolved[k] = true
+		logger.Debug("prompted variable resolved", "key", k, "source", "prompt")
 	}
 	for k := range provided {
 		resolved[k] = true
 	}
 
 	// Iterative conditional passes: each round handles one dependency layer.
+	pass := 2
 	for len(remaining) > 0 {
 		// Find keys whose gate variables are all resolved (or not in schema).
 		var ready []string
@@ -275,6 +293,7 @@ func promptContext(
 		}
 
 		if len(ready) == 0 {
+			logger.Debug("no more resolvable conditional variables", "remaining_count", len(remaining))
 			break // no progress: remaining keys have unresolvable dependencies
 		}
 
@@ -287,14 +306,21 @@ func promptContext(
 			}
 		}
 
-		if err := runPromptPass(ctx, schema, toPrompt, provided); err != nil {
-			return err
+		if len(toPrompt) > 0 {
+			logger.Debug("starting prompt pass", "pass", pass, "conditional_vars_count", len(toPrompt))
+			if err := runPromptPass(ctx, schema, toPrompt, provided, logger); err != nil {
+				return err
+			}
+			for _, k := range toPrompt {
+				logger.Debug("prompted variable resolved", "key", k, "source", "prompt")
+			}
 		}
 
 		for _, k := range ready {
 			resolved[k] = true
 			delete(remaining, k)
 		}
+		pass++
 	}
 
 	return nil
@@ -307,16 +333,25 @@ func runPromptPass(
 	schema map[string]any,
 	keys []string,
 	provided map[string]bool,
+	logger *slog.Logger,
 ) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	logger.Debug("preparing prompt form", "keys_count", len(keys))
+
 	var fields []huh.Field
 	stringResults := make(map[string]*string)
 	boolResults := make(map[string]*bool)
 
 	for _, key := range keys {
 		if provided[key] {
+			logger.Debug("skipping already provided key", "key", key, "source", "provided")
 			continue
 		}
 		defaultVal := schema[key]
+		logger.Debug("preparing prompt for key", "key", key, "default_type", fmt.Sprintf("%T", defaultVal))
 
 		switch v := defaultVal.(type) {
 		case string:
@@ -367,12 +402,16 @@ func runPromptPass(
 	}
 
 	if len(fields) == 0 {
+		logger.Debug("no fields to prompt, skipping")
 		return nil
 	}
 
+	logger.Debug("displaying prompt form", "fields_count", len(fields))
 	if err := huh.NewForm(huh.NewGroup(fields...)).Run(); err != nil {
 		return err
 	}
+
+	logger.Debug("prompt form completed successfully")
 
 	for k, p := range stringResults {
 		ctx[k] = *p
@@ -415,4 +454,3 @@ func toStringOptions(v []any) []string {
 	}
 	return opts
 }
-

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -18,6 +18,7 @@ type Hooks struct {
 	PreUse    []string // each entry: a single command or multiline bash script
 	PostUse   []string
 	EnvPrefix string // prefix for context keys injected as env vars (e.g. "SPECS_")
+	logger    *slog.Logger
 }
 
 // Load reads hook definitions from templateRoot.
@@ -26,11 +27,12 @@ type Hooks struct {
 //   - Directory: hooks/pre-use.sh and hooks/post-use.sh under templateRoot
 //
 // envPrefix is prepended to each context key when injecting env vars (e.g. "SPECS_").
+// logger is used for structured debug logging.
 // Returns an error if both sources are present.
 // Returns an empty *Hooks (not nil) if no hooks are defined at all.
-func Load(templateRoot string, projectConfig map[string]any, envPrefix string) (*Hooks, error) {
+func Load(templateRoot string, projectConfig map[string]any, envPrefix string, logger *slog.Logger) (*Hooks, error) {
 	hasInline := false
-	h := Hooks{EnvPrefix: envPrefix}
+	h := Hooks{EnvPrefix: envPrefix, logger: logger}
 
 	if raw, ok := projectConfig["hooks"]; ok {
 		if err := h.parseInline(raw); err != nil {
@@ -75,19 +77,24 @@ func (h *Hooks) Run(trigger, cwd string, ctx map[string]any, funcMap template.Fu
 		return nil
 	}
 
+	logger := h.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	if _, err := exec.LookPath("bash"); err != nil {
 		return fmt.Errorf("bash not found on PATH: install bash or pass --no-hooks to skip hook execution")
 	}
 
 	env := buildEnv(ctx, h.EnvPrefix)
 
-	for _, cmdTpl := range commands {
+	for i, cmdTpl := range commands {
 		rendered, err := renderCommand(cmdTpl, ctx, funcMap, delims)
 		if err != nil {
 			return fmt.Errorf("rendering hook command: %w", err)
 		}
 
-		slog.Default().Debug("running hook", "trigger", trigger, "command", firstLine(rendered))
+		logger.Debug("running hook", "trigger", trigger, "index", i, "command", firstLine(rendered))
 
 		cmd := exec.Command("bash", "-c", rendered)
 		cmd.Dir = cwd
@@ -114,6 +121,14 @@ func (h *Hooks) Rendered(trigger string, ctx map[string]any, funcMap template.Fu
 	default:
 		return nil, fmt.Errorf("unknown hook trigger: %q", trigger)
 	}
+
+	logger := h.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	logger.Debug("rendering hook commands", "trigger", trigger, "count", len(cmds))
+
 	result := make([]string, len(cmds))
 	for i, cmd := range cmds {
 		rendered, err := renderCommand(cmd, ctx, funcMap, delims)

--- a/pkg/hooks/hooks_test.go
+++ b/pkg/hooks/hooks_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,7 +14,7 @@ import (
 
 // loadNoPrefix calls Load with an empty env prefix, for tests that don't care about prefixing.
 func loadNoPrefix(templateRoot string, projectConfig map[string]any) (*Hooks, error) {
-	return Load(templateRoot, projectConfig, "")
+	return Load(templateRoot, projectConfig, "", slog.Default())
 }
 
 // --- Load: inline hooks ---

--- a/pkg/template/context.go
+++ b/pkg/template/context.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
 	"path/filepath"
@@ -31,8 +32,8 @@ func LoadUserContext(templateRoot string, funcMap texttemplate.FuncMap, delims s
 		return nil, nil, err
 	}
 
-	delete(raw, "hooks")                      // consumed by the hook runner, not a template variable
-	delete(raw, specs.ProjectDelimitersKey)   // consumed by Get(); must not appear as a user variable
+	delete(raw, "hooks")                    // consumed by the hook runner, not a template variable
+	delete(raw, specs.ProjectDelimitersKey) // consumed by Get(); must not appear as a user variable
 
 	userCtx, err = resolveReferencedDefaults(raw, funcMap, delims)
 	return userCtx, computedDefs, err
@@ -97,6 +98,7 @@ func ApplyComputed(ctx map[string]any, defs map[string]string, funcMap texttempl
 			return nil, fmt.Errorf("computed %q: %w", k, err)
 		}
 		result[k] = val
+		slog.Debug("computed value resolved", "key", k, "expression", expr)
 	}
 
 	return result, nil
@@ -115,6 +117,7 @@ func LoadProjectFile(templateRoot string) (map[string]any, error) {
 	hasYML := ymlErr == nil
 
 	if hasYAML && hasYML {
+		slog.Debug("both project.yaml and project.yml exist", "template_root", templateRoot)
 		return nil, specs.ErrAmbiguousProjectFile
 	}
 
@@ -125,6 +128,7 @@ func LoadProjectFile(templateRoot string) (map[string]any, error) {
 			chosen = ymlPath
 			chosenName = specs.ProjectYMLFile
 		}
+		slog.Debug("loading project file", "path", chosen, "file", chosenName)
 		data, err := os.ReadFile(chosen)
 		if err != nil {
 			return nil, fmt.Errorf("reading %s: %w", chosenName, err)
@@ -137,6 +141,7 @@ func LoadProjectFile(templateRoot string) (map[string]any, error) {
 	}
 
 	jsonPath := filepath.Join(templateRoot, specs.ProjectJSONFile)
+	slog.Debug("loading project file", "path", jsonPath, "file", specs.ProjectJSONFile)
 	data, err := os.ReadFile(jsonPath)
 	if err != nil {
 		return nil, fmt.Errorf("%w in %s", specs.ErrProjectFileMissing, templateRoot)

--- a/pkg/template/metadata.go
+++ b/pkg/template/metadata.go
@@ -3,6 +3,7 @@ package template
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -59,16 +60,20 @@ func (t JSONTime) String() string {
 
 // LoadMetadata reads __metadata.json from templateRoot.
 // Missing or malformed metadata is not an error — returns nil, nil.
+// Errors are logged at debug level for diagnostic purposes.
 func LoadMetadata(templateRoot string) (*Metadata, error) {
 	path := filepath.Join(templateRoot, specs.MetadataFile)
 	data, err := os.ReadFile(path)
 	if err != nil {
+		slog.Debug("metadata file not found or unreadable", "path", path, "template_root", templateRoot, "error", err)
 		return nil, nil //nolint:nilerr // missing or unreadable metadata is not an error
 	}
 	var m Metadata
 	if err := json.Unmarshal(data, &m); err != nil {
+		slog.Debug("metadata file malformed", "path", path, "template_root", templateRoot, "error", err)
 		return nil, nil //nolint:nilerr // malformed metadata is silently ignored
 	}
+	slog.Debug("metadata loaded successfully", "path", path, "template_root", templateRoot, "name", m.Name)
 	return &m, nil
 }
 
@@ -87,5 +92,7 @@ func SaveMetadata(templateRoot, name, repository, branch, commit, version string
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(templateRoot, specs.MetadataFile), data, 0644)
+	path := filepath.Join(templateRoot, specs.MetadataFile)
+	slog.Debug("saving metadata", "path", path, "name", name, "repository", repository, "version", version)
+	return os.WriteFile(path, data, 0644)
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -61,13 +61,13 @@ type RenderWarning struct {
 
 // Template holds everything needed to execute a boilr template.
 type Template struct {
-	Root         string                 // path to the template root (contains project.yaml + template/)
-	Context      map[string]any         // user input map with referenced defaults resolved
-	ComputedDefs map[string]string      // raw computed definitions; resolved by ApplyComputed post-prompt
-	Conditionals Conditionals           // varName → Cond; absent means always prompt
-	Referenced   map[string]bool        // schema variables referenced in template files or computed expressions
-	Metadata     *Metadata              // nil if __metadata.json is absent
-	Warnings     []RenderWarning        // non-fatal render issues collected during Execute
+	Root         string            // path to the template root (contains project.yaml + template/)
+	Context      map[string]any    // user input map with referenced defaults resolved
+	ComputedDefs map[string]string // raw computed definitions; resolved by ApplyComputed post-prompt
+	Conditionals Conditionals      // varName → Cond; absent means always prompt
+	Referenced   map[string]bool   // schema variables referenced in template files or computed expressions
+	Metadata     *Metadata         // nil if __metadata.json is absent
+	Warnings     []RenderWarning   // non-fatal render issues collected during Execute
 	cfg          Config
 	logger       *slog.Logger
 	funcMap      texttemplate.FuncMap
@@ -89,6 +89,12 @@ func (t *Template) Delims() specs.Delimiters {
 // Get loads a template from templateRoot. The root must contain either project.yaml or
 // project.json, and a template/ subdirectory.
 func Get(templateRoot string, cfg Config, logger *slog.Logger) (*Template, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	logger.Debug("loading template", "root", templateRoot)
+
 	funcMap := FuncMap(cfg, logger)
 
 	// Resolve delimiters: __delimiters in project.yaml > cfg.Delims > DefaultDelimiters.
@@ -98,17 +104,20 @@ func Get(templateRoot string, cfg Config, logger *slog.Logger) (*Template, error
 	if err != nil {
 		return nil, fmt.Errorf("reading delimiters from project file: %w", err)
 	}
+	logger.Debug("delimiters resolved", "left", delims.Left, "right", delims.Right)
 	cfg.Delims = delims
 
 	userCtx, computedDefs, err := LoadUserContext(templateRoot, funcMap, delims)
 	if err != nil {
 		return nil, err
 	}
+	logger.Debug("user context loaded", "keys_count", len(userCtx), "computed_defs_count", len(computedDefs))
 
 	conds, referenced, err := AnalyzeConditionals(templateRoot, userCtx, funcMap, delims)
 	if err != nil {
 		return nil, err
 	}
+	logger.Debug("conditionals analyzed", "conditional_vars_count", len(conds), "referenced_vars_count", len(referenced))
 
 	// Also count variables that only appear in computed expressions as referenced.
 	for _, expr := range computedDefs {
@@ -125,6 +134,9 @@ func Get(templateRoot string, cfg Config, logger *slog.Logger) (*Template, error
 	}
 
 	meta, _ := LoadMetadata(templateRoot) // missing/malformed metadata is not an error
+	if meta != nil {
+		logger.Debug("metadata loaded", "name", meta.Name, "repository", meta.Repository, "version", meta.Version)
+	}
 
 	return &Template{
 		Root:         templateRoot,
@@ -154,8 +166,11 @@ func (t *Template) Execute(targetDir string) error {
 	}
 
 	srcRoot := filepath.Join(t.Root, specs.TemplateDirFile)
+	t.logger.Debug("starting template execution", "template_root", t.Root, "target_dir", targetDir, "src_root", srcRoot)
 
-	return filepath.WalkDir(srcRoot, func(srcPath string, d fs.DirEntry, err error) error {
+	var renderedCount, verbatimCount, skippedCount int
+
+	result := filepath.WalkDir(srcRoot, func(srcPath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -167,6 +182,7 @@ func (t *Template) Execute(targetDir string) error {
 
 		// 1. Skip OS/editor metadata files.
 		if ignoredFiles[d.Name()] {
+			t.logger.Debug("skipping ignored file", "path", rel, "file_type", "os_metadata")
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -176,7 +192,8 @@ func (t *Template) Execute(targetDir string) error {
 		// 2. Render the relative path as a template to get the destination path.
 		destRel, err := t.renderName(rel, ctx)
 		if err != nil || strings.TrimSpace(destRel) == "" {
-			t.logger.Debug("skipping path", "path", rel, "error", err)
+			t.logger.Debug("skipping path", "path", rel, "error", err, "source", "render_name")
+			skippedCount++
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -185,6 +202,8 @@ func (t *Template) Execute(targetDir string) error {
 
 		// 3. Skip if any path segment is empty (conditional directory exclusion).
 		if hasEmptySegment(destRel) {
+			t.logger.Debug("skipping path with empty segment", "path", rel, "dest_rel", destRel)
+			skippedCount++
 			if d.IsDir() {
 				return filepath.SkipDir
 			}
@@ -195,16 +214,24 @@ func (t *Template) Execute(targetDir string) error {
 
 		// 4. Directory: create it.
 		if d.IsDir() {
+			t.logger.Debug("creating directory", "path", rel, "dest", destPath)
 			return os.MkdirAll(destPath, 0755)
 		}
 
 		// 5. File: determine copy strategy.
 		relForward := filepath.ToSlash(rel)
 		if t.verbatim.Matches(relForward) || isBinary(srcPath) {
+			t.logger.Debug("copying file verbatim", "path", rel, "dest", destPath, "reason", "verbatim_or_binary")
+			verbatimCount++
 			return copyFile(srcPath, destPath)
 		}
+		t.logger.Debug("rendering file", "path", rel, "dest", destPath)
+		renderedCount++
 		return t.renderFile(srcPath, destPath, relForward, ctx)
 	})
+
+	t.logger.Info("template execution completed", "rendered", renderedCount, "verbatim", verbatimCount, "skipped", skippedCount)
+	return result
 }
 
 // renderName renders a file/directory path template using the configured delimiters.

--- a/pkg/util/git/git.go
+++ b/pkg/util/git/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -19,6 +20,9 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
+// defaultLogger is used when no logger is provided.
+var defaultLogger = slog.Default()
+
 // CloneOptions controls how a repository is cloned.
 type CloneOptions struct {
 	// Branch is the branch (or tag) to check out. Empty means the remote's default branch.
@@ -33,6 +37,8 @@ type CloneOptions struct {
 // SSH URLs (git@host:path or ssh://host/path) are detected automatically and authenticated
 // via SSH agent or standard key files in ~/.ssh.
 func Clone(url, dir string, opts CloneOptions) error {
+	defaultLogger.Debug("cloning repository", "url", url, "dir", dir, "branch", opts.Branch, "depth", opts.Depth)
+
 	cloneOpts := &gogit.CloneOptions{
 		URL:      url,
 		Depth:    opts.Depth,
@@ -44,6 +50,7 @@ func Clone(url, dir string, opts CloneOptions) error {
 	}
 
 	if isSSHURL(url) {
+		defaultLogger.Debug("SSH URL detected, setting up SSH auth")
 		auth, err := sshAuth(url)
 		if err != nil {
 			return err
@@ -60,6 +67,7 @@ func Clone(url, dir string, opts CloneOptions) error {
 	if err != nil {
 		return fmt.Errorf("cloning %s: %w", url, err)
 	}
+	defaultLogger.Debug("repository cloned successfully", "url", url, "dir", dir)
 	return nil
 }
 
@@ -67,9 +75,11 @@ func Clone(url, dir string, opts CloneOptions) error {
 // This lets callers pass version tags ("0.1.0", "v1.2.3") or branch names
 // ("main") without needing to know which kind of ref it is.
 func cloneWithRef(url, dir string, cloneOpts *gogit.CloneOptions, ref string) error {
+	defaultLogger.Debug("trying ref as tag", "url", url, "ref", ref)
 	cloneOpts.ReferenceName = plumbing.NewTagReferenceName(ref)
 	_, err := gogit.PlainClone(dir, false, cloneOpts)
 	if err == nil {
+		defaultLogger.Debug("cloned tag successfully", "url", url, "tag", ref)
 		return nil
 	}
 	if !strings.Contains(err.Error(), "couldn't find remote ref") {
@@ -77,12 +87,14 @@ func cloneWithRef(url, dir string, cloneOpts *gogit.CloneOptions, ref string) er
 	}
 
 	// Tag ref not found — retry as a branch.
+	defaultLogger.Debug("tag not found, retrying as branch", "url", url, "ref", ref)
 	os.RemoveAll(dir)
 	cloneOpts.ReferenceName = plumbing.NewBranchReferenceName(ref)
 	_, err = gogit.PlainClone(dir, false, cloneOpts)
 	if err != nil {
 		return fmt.Errorf("cloning %s: %w", url, err)
 	}
+	defaultLogger.Debug("cloned branch successfully", "url", url, "branch", ref)
 	return nil
 }
 
@@ -100,6 +112,8 @@ type DescribeResult struct {
 // Describe returns version information for the repository at dir.
 // Returns an error only when dir is not a git repository or HEAD cannot be read.
 func Describe(dir string) (DescribeResult, error) {
+	defaultLogger.Debug("describing git repository", "dir", dir)
+
 	repo, err := gogit.PlainOpen(dir)
 	if err != nil {
 		return DescribeResult{}, fmt.Errorf("opening repository at %s: %w", dir, err)
@@ -107,11 +121,13 @@ func Describe(dir string) (DescribeResult, error) {
 
 	head, err := repo.Head()
 	if err != nil {
-		return DescribeResult{}, fmt.Errorf("reading HEAD: %w", err)
+		return DescribeResult{}, fmt.Errorf("reading HEAD in %s: %w", dir, err)
 	}
 
 	commit := head.Hash().String()
 	shortHash := commit[:7]
+
+	defaultLogger.Debug("HEAD resolved", "dir", dir, "commit", commit, "short_hash", shortHash)
 
 	dirty := false
 	if wt, err := repo.Worktree(); err == nil {
@@ -127,10 +143,16 @@ func Describe(dir string) (DescribeResult, error) {
 		}
 	}
 
-	return DescribeResult{
+	if dirty {
+		defaultLogger.Debug("repository has uncommitted changes", "dir", dir)
+	}
+
+	result := DescribeResult{
 		Commit:  commit,
 		Version: buildVersion(repo, head.Hash(), shortHash, dirty),
-	}, nil
+	}
+	defaultLogger.Debug("describe completed", "dir", dir, "version", result.Version)
+	return result, nil
 }
 
 // buildVersion constructs a version string in git-describe style.
@@ -288,39 +310,52 @@ func (r RemoteCheckResult) Err() error {
 //
 // On failure, ErrorKind is set in the result and error is nil.
 func CheckRemoteContext(ctx context.Context, dir, url, branch string) (RemoteCheckResult, error) {
+	defaultLogger.Debug("checking remote status", "dir", dir, "url", url, "branch", branch)
+
 	repo, err := gogit.PlainOpen(dir)
 	if err != nil {
+		defaultLogger.Debug("failed to open repository", "dir", dir, "error", err)
 		return RemoteCheckResult{ErrorKind: CheckErrorUnknown}, nil
 	}
 
 	remote, err := repo.Remote("origin")
 	if err != nil {
+		defaultLogger.Debug("failed to get remote origin", "dir", dir, "error", err)
 		return RemoteCheckResult{ErrorKind: CheckErrorUnknown}, nil
 	}
 
 	listOpts := &gogit.ListOptions{}
 	if isSSHURL(url) {
+		defaultLogger.Debug("SSH URL detected for remote check, setting up SSH auth")
 		auth, err := sshAuth(url)
 		if err != nil {
+			defaultLogger.Debug("SSH auth failed for remote check", "url", url, "error", err)
 			return RemoteCheckResult{ErrorKind: CheckErrorAuth}, nil
 		}
 		listOpts.Auth = auth
 	}
 
+	defaultLogger.Debug("listing remote refs", "dir", dir, "url", url)
 	refs, err := remote.ListContext(ctx, listOpts)
 	if err != nil {
 		if ctx.Err() != nil {
+			defaultLogger.Debug("remote check cancelled by context", "dir", dir)
 			return RemoteCheckResult{ErrorKind: CheckErrorNetwork}, nil
 		}
-		return RemoteCheckResult{ErrorKind: classifyRemoteError(err)}, nil
+		errKind := classifyRemoteError(err)
+		defaultLogger.Debug("remote check failed", "dir", dir, "url", url, "error_kind", errKind, "error", err)
+		return RemoteCheckResult{ErrorKind: errKind}, nil
 	}
 
 	head, err := repo.Head()
 	if err != nil {
+		defaultLogger.Debug("failed to read HEAD", "dir", dir, "error", err)
 		return RemoteCheckResult{ErrorKind: CheckErrorUnknown}, nil
 	}
 
-	return resolveStatus(refs, head.Hash(), branch), nil
+	result := resolveStatus(refs, head.Hash(), branch)
+	defaultLogger.Debug("remote check completed", "dir", dir, "url", url, "branch", branch, "is_up_to_date", result.IsUpToDate, "latest_version", result.LatestVersion)
+	return result, nil
 }
 
 // CheckRemote is a context-free convenience wrapper around CheckRemoteContext.


### PR DESCRIPTION
- Add debug logs to hook execution with trigger, index, and command info
- Add debug logs to git operations (Clone, Describe, CheckRemoteContext)
- Add debug logs to render pipeline (template load, Execute, per-file decisions)
- Add debug logs to prompt resolution (context sources, computed values)
- Promote template execution summary to Info level (rendered/verbatim/skipped counts)
- Fix silent error swallowing in template_list.go by logging errors
- Add Logging section to docs/content/docs/architecture/overview.md

Acceptance criteria met:
- specs --debug template use produces structured logs covering template load, prompt resolution per key, computed resolution per key, render decision per file, and per-hook invocation
- specs --debug --output=json template ls emits NDJSON logs to stderr
- No silent error swallowing where diagnostic info is available
- Logging section added to overview.md