### PR TITLE
Demote template execution summary log from info to debug

### DIFF
--- a/docs/content/docs/architecture/overview.md
+++ b/docs/content/docs/architecture/overview.md
@@ -307,6 +307,11 @@ package-level `slog.Debug/Info/Warn/Error` functions, which route through the gl
 logger. `NewApp()` calls `slog.SetDefault` to install a text handler at `Info` level;
 `PersistentPreRunE` re-sets it when `--debug --output=json` swaps the handler to JSON.
 
+`slog` is a **debug-only diagnostic channel** on **stderr** — it is silent on a normal run (every
+log point is `Debug`, suppressed at the default `Info` level) and is distinct from the two
+`output.Writer` formats (`pretty`/`json`) that produce user-facing output on stdout. Do not use
+`slog` for user-facing reporting; use `output.Writer`.
+
 ### Flags
 
 | Flag | Effect |
@@ -320,7 +325,7 @@ logger. `NewApp()` calls `slog.SetDefault` to install a text handler at `Info` l
 |---------|----------|-------|------------|
 | `internal/template` | `Get` | Debug | `template`, `keys`, `computed` |
 | `internal/template` | `Execute` | Debug | `path`, `dest`, `action` (render/verbatim/skip) |
-| `internal/template` | `Execute` | Info | `template`, `dest`, `rendered`, `verbatim`, `skipped` (summary) |
+| `internal/template` | `Execute` | Debug | `template`, `dest`, `rendered`, `verbatim`, `skipped` (summary) |
 | `internal/template` | `ApplyComputed` | Debug | `key`, `source`="computed" |
 | `internal/hooks` | `Hooks.Run` | Debug | `trigger`, `commands`, `command` |
 | `internal/cmd` | `executeTemplate` | Debug | `key`, `source` (values_file/arg_flag/default/prompt) — one log per key, final source only |

--- a/internal/template/logging_test.go
+++ b/internal/template/logging_test.go
@@ -1,0 +1,53 @@
+package template_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	pkgtemplate "github.com/specsnl/specs-cli/internal/template"
+)
+
+// TestExecute_SummaryLogIsDebugLevel guards against the "template execution complete"
+// summary leaking onto normal runs. It is a diagnostic log and must only surface at
+// Debug level (--debug); at the default Info level it must stay silent so it does not
+// print an unstyled line to the terminal.
+func TestExecute_SummaryLogIsDebugLevel(t *testing.T) {
+	root := buildTemplate(t, "Name: World\n", map[string][]byte{
+		"hello.txt": []byte("Hello {{ .Name }}"),
+	})
+
+	runExecute := func(t *testing.T, level slog.Level) string {
+		t.Helper()
+		var buf bytes.Buffer
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: level})))
+		t.Cleanup(func() { slog.SetDefault(prev) })
+
+		tmpl, err := pkgtemplate.Get(root, pkgtemplate.Config{})
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if err := tmpl.Execute(t.TempDir()); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		return buf.String()
+	}
+
+	// At Info level (the default, no --debug) the summary must NOT surface.
+	if out := runExecute(t, slog.LevelInfo); strings.Contains(out, "template execution complete") {
+		t.Errorf("summary log leaked at Info level:\n%s", out)
+	}
+
+	// At Debug level (--debug) it must still be available, with its attributes.
+	out := runExecute(t, slog.LevelDebug)
+	if !strings.Contains(out, "template execution complete") {
+		t.Fatalf("summary log missing at Debug level:\n%s", out)
+	}
+	for _, attr := range []string{"rendered=", "verbatim=", "skipped="} {
+		if !strings.Contains(out, attr) {
+			t.Errorf("summary log missing attribute %q at Debug level:\n%s", attr, out)
+		}
+	}
+}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -223,7 +223,7 @@ func (t *Template) Execute(targetDir string) error {
 		return walkErr
 	}
 
-	slog.Info("template execution complete",
+	slog.Debug("template execution complete",
 		"template", t.Root,
 		"dest", targetDir,
 		"rendered", rendered,


### PR DESCRIPTION
## Summary
- Demote the `template execution complete` log (`internal/template/Execute`) from `slog.Info` to `slog.Debug` — it was the only info-level slog call, so it leaked an unstyled diagnostic line onto every normal run; it now stays silent unless `--debug` is set, consistent with the package's other diagnostic logs.
- Add a test asserting the summary is suppressed at info level and still emitted (with its attributes) at debug level.
- Update the architecture docs: flip the log-point row to Debug and clarify that `slog` is a debug-only diagnostic channel on stderr, distinct from the `output.Writer` user-facing formats.