### PR TITLE
Add 'add' alias for 'template download' command

### DIFF
--- a/docs/content/docs/commands/template.md
+++ b/docs/content/docs/commands/template.md
@@ -11,7 +11,7 @@ Manage a local registry of named templates. Unlike `specs use`, downloaded templ
 |------------|-------------|
 | `list` / `ls` | List registered templates with update status. Stale statuses (older than 24 hours) are refreshed automatically. Use `--output json` for machine-readable NDJSON output. |
 | `save <path> <name>` | Register a local directory as a template |
-| `download <source> <name>` | Download a remote template and save it to the local registry |
+| `download` / `add <source> <name>` | Download a remote template and save it to the local registry |
 | `use <name> <target-dir>` | Execute a registered template |
 | `validate <path>` | Check if a template directory is valid |
 | `rename` / `mv <old> <new>` | Rename a registered template |

--- a/internal/cmd/template_download.go
+++ b/internal/cmd/template_download.go
@@ -17,9 +17,10 @@ func newTemplateDownloadCmd(app *App) *cobra.Command {
 	var force bool
 
 	cmd := &cobra.Command{
-		Use:   "download <source> <name>",
-		Short: "Download a template from a remote repository",
-		Args:  cobra.ExactArgs(2),
+		Use:     "download <source> <name>",
+		Aliases: []string{"add"},
+		Short:   "Download a template from a remote repository",
+		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rawSource, name := args[0], args[1]
 

--- a/internal/cmd/template_download_test.go
+++ b/internal/cmd/template_download_test.go
@@ -24,3 +24,14 @@ func TestDownload_LocalSource_IsErrLocalSource(t *testing.T) {
 		t.Errorf("expected ErrLocalSource, got %v", err)
 	}
 }
+
+func TestDownload_AddAlias(t *testing.T) {
+	withTempRegistry(t)
+
+	// The "add" alias resolves to the download command, so a local source is
+	// rejected the same way as `template download`.
+	_, err := executeCmd("template", "add", "./local-path", "my-tpl")
+	if !errors.Is(err, specs.ErrLocalSource) {
+		t.Errorf("expected ErrLocalSource via add alias, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `add` as an alias for `specs template download` (closes #84)
- Add `TestDownload_AddAlias` verifying the alias routes to the download command
- Document the alias in the `specs template` subcommands table