### PR TITLE
Add Updated column to template list

### DIFF
--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -379,6 +379,7 @@ type Metadata struct {
     Repository string   `json:"Repository"`
     Branch     string   `json:"Branch,omitempty"`
     Created    JSONTime `json:"Created"`            // set on first install; preserved across upgrades
+    Updated    JSONTime `json:"Updated"`            // set on first install; refreshed on each upgrade
     Commit     string   `json:"Commit,omitempty"`   // full SHA-1 of HEAD at download/upgrade
     Version    string   `json:"Version,omitempty"`  // git-describe-style version string
 }
@@ -387,8 +388,17 @@ type Metadata struct {
 `Created` records when the template was first added to the registry (via
 `template download` or `template save`) and is intentionally preserved across
 `template upgrade` so the `list` command's `Created` column reflects the
-original install time, not the most recent upgrade. `Commit` and `Version` are
-the only fields that change on upgrade.
+original install time, not the most recent upgrade.
+
+`Updated` records the last time the template was upgraded (via `template
+upgrade`). On first install it is set to the same timestamp as `Created`, and it
+is refreshed to the current time on each successful upgrade. The `list` command's
+`Updated` column reflects this value. Metadata written before the `Updated` field
+existed has no `Updated` key; `LoadMetadata` falls back to `Created` in that case
+so pre-existing templates still display a sensible value.
+
+`Commit` and `Version` change on upgrade (alongside `Updated`); `Created` never
+does.
 
 `JSONTime` wraps `time.Time` with RFC1123Z serialisation and a human-readable `"X time ago"`
 display format for the `list` command.

--- a/internal/cmd/metadata_test.go
+++ b/internal/cmd/metadata_test.go
@@ -13,7 +13,7 @@ func TestWriteMetadata_PreservesSuppliedCreated(t *testing.T) {
 	// RFC1123Z has second-level precision, so truncate before round-tripping.
 	want := time.Now().Add(-30 * 24 * time.Hour).UTC().Truncate(time.Second)
 
-	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "abc123", "v1.0.0", want); err != nil {
+	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "abc123", "v1.0.0", want, want); err != nil {
 		t.Fatalf("SaveMetadata: %v", err)
 	}
 
@@ -27,6 +27,9 @@ func TestWriteMetadata_PreservesSuppliedCreated(t *testing.T) {
 	if !got.Created.Time.Equal(want) {
 		t.Errorf("Created = %s, want %s", got.Created.Time, want)
 	}
+	if !got.Updated.Time.Equal(want) {
+		t.Errorf("Updated = %s, want %s", got.Updated.Time, want)
+	}
 }
 
 // Verifies the upgrade-flow contract: passing meta.Created.Time back into
@@ -36,8 +39,8 @@ func TestWriteMetadata_UpgradeRoundTripPreservesCreated(t *testing.T) {
 
 	original := time.Now().Add(-90 * 24 * time.Hour).UTC().Truncate(time.Second)
 
-	// Initial install.
-	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "old-sha", "v1.0.0", original); err != nil {
+	// Initial install: created and updated are the same.
+	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "old-sha", "v1.0.0", original, original); err != nil {
 		t.Fatalf("SaveMetadata (install): %v", err)
 	}
 
@@ -49,9 +52,11 @@ func TestWriteMetadata_UpgradeRoundTripPreservesCreated(t *testing.T) {
 		t.Fatal("LoadMetadata returned nil metadata")
 	}
 
-	// Simulate an upgrade: re-write metadata with new commit/version but the
-	// original Created threaded through, the same way registry.Upgrade does.
-	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "new-sha", "v1.1.0", meta.Created.Time); err != nil {
+	// Simulate an upgrade: re-write metadata with new commit/version and a fresh
+	// Updated timestamp but the original Created threaded through, the same way
+	// registry.Upgrade does.
+	upgradedAt := time.Now().Add(-1 * 24 * time.Hour).UTC().Truncate(time.Second)
+	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "new-sha", "v1.1.0", meta.Created.Time, upgradedAt); err != nil {
 		t.Fatalf("SaveMetadata (upgrade): %v", err)
 	}
 
@@ -64,6 +69,9 @@ func TestWriteMetadata_UpgradeRoundTripPreservesCreated(t *testing.T) {
 	}
 	if !upgraded.Created.Time.Equal(original) {
 		t.Errorf("Created after upgrade = %s, want %s", upgraded.Created.Time, original)
+	}
+	if !upgraded.Updated.Time.Equal(upgradedAt) {
+		t.Errorf("Updated after upgrade = %s, want %s", upgraded.Updated.Time, upgradedAt)
 	}
 	if upgraded.Commit != "new-sha" {
 		t.Errorf("Commit after upgrade = %q, want %q", upgraded.Commit, "new-sha")

--- a/internal/cmd/template_download.go
+++ b/internal/cmd/template_download.go
@@ -63,7 +63,8 @@ func newTemplateDownloadCmd(app *App) *cobra.Command {
 
 			// git layer logs describe result or failure
 			desc, _ := pkggit.Describe(dest)
-			if err := pkgtemplate.SaveMetadata(dest, name, src.CloneURL, branch, desc.Commit, desc.Version, time.Now().UTC()); err != nil {
+			now := time.Now().UTC()
+			if err := pkgtemplate.SaveMetadata(dest, name, src.CloneURL, branch, desc.Commit, desc.Version, now, now); err != nil {
 				return err
 			}
 

--- a/internal/cmd/template_list.go
+++ b/internal/cmd/template_list.go
@@ -52,7 +52,7 @@ func newTemplateListCmd(app *App) *cobra.Command {
 				if meta != nil && meta.Repository != "" && meta.Branch == "" {
 					if b, err := pkggit.CurrentBranch(root); err == nil {
 						meta.Branch = b
-						if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, b, meta.Commit, meta.Version, meta.Created.Time); err != nil {
+						if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, b, meta.Commit, meta.Version, meta.Created.Time, meta.Updated.Time); err != nil {
 							slog.Debug("failed to persist resolved branch", "template", name, "error", err)
 						}
 					}
@@ -113,21 +113,22 @@ func newTemplateListCmd(app *App) *cobra.Command {
 			}
 			_ = eg.Wait()
 
-			headers := []string{"Name", "Repository", "Version", "Status", "Created"}
+			headers := []string{"Name", "Repository", "Version", "Status", "Created", "Updated"}
 			var rows [][]string
 
 			for _, entry := range tmplEntries {
-				repo, version, created := "-", "-", "-"
+				repo, version, created, updated := "-", "-", "-", "-"
 				if entry.meta != nil {
 					repo = entry.meta.Repository
 					created = entry.meta.Created.String()
+					updated = entry.meta.Updated.String()
 					if entry.meta.Version != "" {
 						version = entry.meta.Version
 					}
 				}
 				hasRemote := entry.meta != nil && entry.meta.Repository != "" && entry.meta.Branch != ""
 				statusStr := statusLabel(entry.status, hasRemote)
-				rows = append(rows, []string{entry.name, repo, version, statusStr, created})
+				rows = append(rows, []string{entry.name, repo, version, statusStr, created, updated})
 			}
 
 			if len(rows) == 0 {

--- a/internal/cmd/template_list_test.go
+++ b/internal/cmd/template_list_test.go
@@ -87,6 +87,37 @@ func TestList_JSONOutput(t *testing.T) {
 	}
 }
 
+func TestList_UpdatedColumn(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	tmplDir := filepath.Join(registryDir, "local-tpl")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	created := time.Now().Add(-30 * 24 * time.Hour).UTC()
+	updated := time.Now().Add(-2 * 24 * time.Hour).UTC()
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "/local/path", "", "", "", created, updated); err != nil {
+		t.Fatal(err)
+	}
+
+	// Table output must carry an Updated header.
+	out, err := executeCmd("template", "list")
+	if err != nil {
+		t.Fatalf("template list: %v", err)
+	}
+	if !strings.Contains(out, "Updated") {
+		t.Errorf("expected table to contain 'Updated' header, got: %q", out)
+	}
+
+	// JSON output must carry an Updated key distinct from Created.
+	jsonOut, err := executeCmd("template", "list", "--output=json")
+	if err != nil {
+		t.Fatalf("template list --output=json: %v", err)
+	}
+	if !strings.Contains(jsonOut, `"Updated"`) {
+		t.Errorf("expected JSON to contain 'Updated' key, got: %q", jsonOut)
+	}
+}
+
 func TestList_StatusColumn_LocalNoStatus(t *testing.T) {
 	registryDir := withTempRegistry(t)
 	tmplDir := filepath.Join(registryDir, "local-tpl")
@@ -95,7 +126,7 @@ func TestList_StatusColumn_LocalNoStatus(t *testing.T) {
 	}
 	// Local template: repository set but no branch AND no git repo — branch
 	// resolution fails, so status stays "-".
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "/local/path", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "/local/path", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -134,7 +165,7 @@ func TestList_StatusColumn_EmptyBranchWithGitRepo(t *testing.T) {
 
 	// Save metadata with empty Branch — simulates a template downloaded without
 	// an explicit branch specification.
-	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -162,7 +193,7 @@ func TestList_StatusColumn_FreshUpToDate(t *testing.T) {
 	if err := os.MkdirAll(tmplDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 	// Write a fresh status so no network call is made.
@@ -216,7 +247,7 @@ func TestList_StatusColumn_NetworkWarn(t *testing.T) {
 	if err := os.MkdirAll(tmplDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 	// Write a stale status with network error.
@@ -249,7 +280,7 @@ func TestList_ConcurrencyCap(t *testing.T) {
 		if err := os.MkdirAll(tmplDir, 0755); err != nil {
 			t.Fatal(err)
 		}
-		if err := pkgtemplate.SaveMetadata(tmplDir, name, "https://example.com/repo", "main", "", "", time.Now().UTC()); err != nil {
+		if err := pkgtemplate.SaveMetadata(tmplDir, name, "https://example.com/repo", "main", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 			t.Fatal(err)
 		}
 		stale := &pkgtemplate.TemplateStatus{
@@ -300,7 +331,7 @@ func TestList_PerCheckTimeout(t *testing.T) {
 	if err := os.MkdirAll(tmplDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "slow-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "slow-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 	stale := &pkgtemplate.TemplateStatus{

--- a/internal/cmd/template_save.go
+++ b/internal/cmd/template_save.go
@@ -47,7 +47,8 @@ func newTemplateSaveCmd(app *App) *cobra.Command {
 				return err
 			}
 			desc, _ := pkggit.Describe(srcPath)
-			if err := pkgtemplate.SaveMetadata(dest, name, "local:"+absPath, "", desc.Commit, desc.Version, time.Now().UTC()); err != nil {
+			now := time.Now().UTC()
+			if err := pkgtemplate.SaveMetadata(dest, name, "local:"+absPath, "", desc.Commit, desc.Version, now, now); err != nil {
 				return err
 			}
 

--- a/internal/cmd/template_update.go
+++ b/internal/cmd/template_update.go
@@ -60,7 +60,7 @@ func newTemplateUpdateCmd(app *App) *cobra.Command {
 					}
 					branch = b
 					// Persist the resolved branch so future runs skip this fallback.
-					if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, branch, meta.Commit, meta.Version, meta.Created.Time); err != nil {
+					if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, branch, meta.Commit, meta.Version, meta.Created.Time, meta.Updated.Time); err != nil {
 						slog.Debug("failed to persist resolved branch", "template", name, "error", err)
 					}
 				}

--- a/internal/cmd/template_update_test.go
+++ b/internal/cmd/template_update_test.go
@@ -26,7 +26,7 @@ func TestUpdate_NamedLocalTemplate_Skipped(t *testing.T) {
 	if err := os.MkdirAll(tmplDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/some/local/path", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/some/local/path", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -54,7 +54,7 @@ func TestUpdate_NamedLocalTemplate_ProducesNoOutput(t *testing.T) {
 	if err := os.MkdirAll(tmplDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/some/local/path", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/some/local/path", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,7 +81,7 @@ func TestUpdate_LocalTemplate_WithGitHistory_ProducesNoOutput(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(tmplDir, ".git"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-git-tpl", "local:/Users/user/my-template", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-git-tpl", "local:/Users/user/my-template", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cmd/template_upgrade_test.go
+++ b/internal/cmd/template_upgrade_test.go
@@ -17,7 +17,7 @@ func TestUpgrade_LocalSkipped(t *testing.T) {
 	if err := os.MkdirAll(tmplDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/some/local/path", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/some/local/path", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -42,7 +42,7 @@ func TestUpgrade_LocalTemplate_WithGitHistory(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(tmplDir, ".git"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-git-tpl", "local:/Users/user/my-template", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-git-tpl", "local:/Users/user/my-template", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/specsnl/specs-cli/internal/specs"
 	pkgtemplate "github.com/specsnl/specs-cli/internal/template"
@@ -116,7 +117,7 @@ func Upgrade(name string) (UpgradeResult, error) {
 	}
 
 	desc, _ := pkggit.Describe(root) // errors are logged by the git layer
-	if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, newBranch, desc.Commit, desc.Version, meta.Created.Time); err != nil {
+	if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, newBranch, desc.Commit, desc.Version, meta.Created.Time, time.Now().UTC()); err != nil {
 		return UpgradeResult{}, err
 	}
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -73,7 +73,7 @@ func TestLoad_WithMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 	created := time.Now().Add(-24 * time.Hour).UTC().Truncate(time.Second)
-	if err := pkgtemplate.SaveMetadata(tmplDir, "my-tpl", "https://example.com/repo", "main", "abc123", "v1.0.0", created); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "my-tpl", "https://example.com/repo", "main", "abc123", "v1.0.0", created, created); err != nil {
 		t.Fatalf("SaveMetadata: %v", err)
 	}
 
@@ -115,7 +115,7 @@ func TestUpgrade_LocalTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	// "local:" prefix is what `specs template save` stores in Repository.
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/local/path", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-tpl", "local:/local/path", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatalf("SaveMetadata: %v", err)
 	}
 
@@ -143,7 +143,7 @@ func TestUpgrade_LocalTemplate_WithGitHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := pkgtemplate.SaveMetadata(tmplDir, "local-git-tpl", "local:/Users/user/my-template", "", "", "", time.Now().UTC()); err != nil {
+	if err := pkgtemplate.SaveMetadata(tmplDir, "local-git-tpl", "local:/Users/user/my-template", "", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatalf("SaveMetadata: %v", err)
 	}
 

--- a/internal/template/metadata.go
+++ b/internal/template/metadata.go
@@ -16,6 +16,7 @@ type Metadata struct {
 	Repository string   `json:"Repository"`
 	Branch     string   `json:"Branch,omitempty"`
 	Created    JSONTime `json:"Created"`
+	Updated    JSONTime `json:"Updated"`
 	Commit     string   `json:"Commit,omitempty"`
 	Version    string   `json:"Version,omitempty"`
 }
@@ -70,17 +71,25 @@ func LoadMetadata(templateRoot string) (*Metadata, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", specs.MetadataFile, err)
 	}
+	// Metadata written before the Updated field existed has no Updated timestamp.
+	// Fall back to Created so pre-existing templates display a sensible value.
+	if m.Updated.Time.IsZero() {
+		m.Updated = m.Created
+	}
 	return &m, nil
 }
 
-// SaveMetadata writes __metadata.json into templateRoot. The created timestamp is
-// supplied by the caller so that upgrades can preserve the original install time.
-func SaveMetadata(templateRoot, name, repository, branch, commit, version string, created time.Time) error {
+// SaveMetadata writes __metadata.json into templateRoot. The created and updated
+// timestamps are supplied by the caller so that upgrades can preserve the original
+// install time (created) while recording the most recent upgrade (updated). On the
+// first install both timestamps are the same.
+func SaveMetadata(templateRoot, name, repository, branch, commit, version string, created, updated time.Time) error {
 	m := Metadata{
 		Name:       name,
 		Repository: repository,
 		Branch:     branch,
 		Created:    JSONTime{Time: created},
+		Updated:    JSONTime{Time: updated},
 		Commit:     commit,
 		Version:    version,
 	}

--- a/internal/template/metadata_test.go
+++ b/internal/template/metadata_test.go
@@ -197,7 +197,9 @@ func TestSaveMetadata_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	created := time.Now().Add(-7 * 24 * time.Hour).UTC().Truncate(time.Second)
 
-	if err := pkgtemplate.SaveMetadata(dir, "my-tpl", "https://example.com/repo", "main", "abc123", "v1.2.3", created); err != nil {
+	updated := time.Now().Add(-2 * 24 * time.Hour).UTC().Truncate(time.Second)
+
+	if err := pkgtemplate.SaveMetadata(dir, "my-tpl", "https://example.com/repo", "main", "abc123", "v1.2.3", created, updated); err != nil {
 		t.Fatalf("SaveMetadata: %v", err)
 	}
 
@@ -226,13 +228,16 @@ func TestSaveMetadata_RoundTrip(t *testing.T) {
 	if !m.Created.Time.Equal(created) {
 		t.Errorf("Created = %v, want %v", m.Created.Time, created)
 	}
+	if !m.Updated.Time.Equal(updated) {
+		t.Errorf("Updated = %v, want %v", m.Updated.Time, updated)
+	}
 }
 
 func TestSaveMetadata_PreservesCreatedOnUpgrade(t *testing.T) {
 	dir := t.TempDir()
 	original := time.Now().Add(-90 * 24 * time.Hour).UTC().Truncate(time.Second)
 
-	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "old-sha", "v1.0.0", original); err != nil {
+	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "old-sha", "v1.0.0", original, original); err != nil {
 		t.Fatalf("SaveMetadata (install): %v", err)
 	}
 
@@ -241,8 +246,10 @@ func TestSaveMetadata_PreservesCreatedOnUpgrade(t *testing.T) {
 		t.Fatal("LoadMetadata returned nil")
 	}
 
-	// Simulate upgrade: re-write with new sha/version but pass original created.
-	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "new-sha", "v1.1.0", m.Created.Time); err != nil {
+	// Simulate upgrade: re-write with new sha/version, original created preserved
+	// but a fresh updated timestamp.
+	upgradedAt := time.Now().UTC().Truncate(time.Second)
+	if err := pkgtemplate.SaveMetadata(dir, "tpl", "https://example.com/repo", "main", "new-sha", "v1.1.0", m.Created.Time, upgradedAt); err != nil {
 		t.Fatalf("SaveMetadata (upgrade): %v", err)
 	}
 
@@ -253,7 +260,41 @@ func TestSaveMetadata_PreservesCreatedOnUpgrade(t *testing.T) {
 	if !upgraded.Created.Time.Equal(original) {
 		t.Errorf("Created after upgrade = %v, want %v", upgraded.Created.Time, original)
 	}
+	if !upgraded.Updated.Time.Equal(upgradedAt) {
+		t.Errorf("Updated after upgrade = %v, want %v", upgraded.Updated.Time, upgradedAt)
+	}
 	if upgraded.Commit != "new-sha" {
 		t.Errorf("Commit = %q, want %q", upgraded.Commit, "new-sha")
+	}
+}
+
+// Metadata written before the Updated field existed has no Updated key; LoadMetadata
+// must fall back to Created so such templates still display a sensible timestamp.
+func TestLoadMetadata_MissingUpdated_FallsBackToCreated(t *testing.T) {
+	dir := t.TempDir()
+	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	// Hand-write legacy metadata without an Updated field.
+	legacy := `{
+  "Name": "legacy-tpl",
+  "Repository": "https://example.com/repo",
+  "Branch": "main",
+  "Created": "` + created.Format(time.RFC1123Z) + `",
+  "Commit": "abc123",
+  "Version": "v1.0.0"
+}`
+	if err := os.WriteFile(filepath.Join(dir, specs.MetadataFile), []byte(legacy), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := pkgtemplate.LoadMetadata(dir)
+	if err != nil {
+		t.Fatalf("LoadMetadata: %v", err)
+	}
+	if m == nil {
+		t.Fatal("LoadMetadata returned nil")
+	}
+	if !m.Updated.Time.Equal(created) {
+		t.Errorf("Updated = %v, want fallback to Created %v", m.Updated.Time, created)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #82.

Adds an **Updated** column to `specs template list`. The column shows the last time a template was upgraded. When a template is first added it holds the same timestamp as **Created**.

## Changes

- **Metadata** gains an `Updated` field, serialised alongside `Created` in `__metadata.json`.
- **`SaveMetadata`** now takes an explicit `updated` timestamp so each caller controls it:
  - `template download` / `template save` (first install) → `Updated == Created == now`.
  - `template upgrade` → `Updated` refreshed to now, `Created` preserved.
  - Branch-persistence rewrites in `list` / `update` leave both timestamps untouched (they are not upgrades).
- **`LoadMetadata`** falls back to `Created` when `Updated` is absent, so templates registered before this change still display a sensible value.
- **`template list`** renders the new `Updated` column (table and `--output=json`).

## Tests

- Added coverage for the install/upgrade timestamp contract and the missing-`Updated` fallback.
- Added a `template list` test asserting the `Updated` column appears in both table and JSON output.
- Updated all existing `SaveMetadata` call sites in tests for the new signature.

## Docs

- Updated `docs/content/docs/architecture/template-engine.md` to document the `Updated` field and its fallback behaviour.

## Verification

- `go vet ./...`, `go test -race ./...`, and the integration suite all pass.
- Manually built the binary and confirmed `specs template list` shows `Updated` — "just now" for a freshly saved template, and falling back to `Created` for pre-existing templates.