### PR TITLE
Fix git clone integration test for renamed repo and valid tag

### DIFF
--- a/internal/util/git/git_test.go
+++ b/internal/util/git/git_test.go
@@ -46,8 +46,8 @@ func TestClone_SpecificBranch(t *testing.T) {
 func TestClone_SpecificTag(t *testing.T) {
 	dir := t.TempDir()
 
-	err := pkggit.Clone("https://github.com/specsnl/boilr-laravel-project", dir, pkggit.CloneOptions{
-		Branch: "0.1.0",
+	err := pkggit.Clone("https://github.com/specsnl/specs-laravel-project", dir, pkggit.CloneOptions{
+		Branch: "1.0.0",
 		Depth:  1,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- `specsnl/boilr-laravel-project` was renamed to `specs-laravel-project`; point the clone URL in `TestClone_SpecificTag` at the current name.
- The `0.1.0` tag no longer exists (tags now start at `1.0.0`), which failed the test with `couldn't find remote ref`; switch to `1.0.0`, which still contains the asserted `template/composer.json`.
- Verified locally: `go vet`, `go test -race ./...`, integration tests, and build all pass.