### PR TITLE
Add __specs__version constraint gate for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ specs template use my-template ./my-project
 
 ---
 
+## The project file
+
+A template's `project.yml` declares its variables, defaults, computed values, and hooks. A few `__`-prefixed keys are reserved by `specs` and never exposed as template variables:
+
+| Key | Purpose |
+|-----|---------|
+| `__delimiters` | Override the default `{{ }}` template delimiters with a custom pair (e.g. `[[ ]]`). |
+| `__specs__version` | Declare a [semver](https://github.com/Masterminds/semver) constraint on the `specs` CLI version required to use the template, e.g. `__specs__version: ^0.1.0`. `specs use` and `specs template use` refuse to run the template unless the running binary satisfies the constraint (development builds are exempt; `specs template save` skips the check). |
+
+See the [documentation](https://cli.specs.dev) for the full project-file reference.
+
+---
+
 ## Development environment
 
 ### Overview

--- a/docs/content/docs/architecture/overview.md
+++ b/docs/content/docs/architecture/overview.md
@@ -261,6 +261,8 @@ so that callers can use `errors.Is` to distinguish them:
 | `ErrLocalSource` | `local_source` | Local path given to a command that requires a remote URL |
 | `ErrInvalidComputedDef` | `invalid_computed_def` | `computed:` entry in `project.yaml` has wrong type, value type mismatch, or key conflict |
 | `ErrCyclicDependency` | `cyclic_dependency` | Cycle detected among computed or referenced-default keys |
+| `ErrInvalidSpecsVersion` | `invalid_specs_version` | `__specs__version` in `project.yaml` is not a string or not a parseable semver constraint |
+| `ErrSpecsVersionUnsatisfied` | `specs_version_unsatisfied` | Running CLI version does not satisfy the template's `__specs__version` constraint |
 
 `specs.KindOf(err error) string` returns the stable kind string for any error in the chain,
 or `""` when no known sentinel is wrapped.

--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -87,6 +87,36 @@ MARIADB_DATABASE: "[[ .ProjectShortName | toSnakeCase ]]_test"
 
 ---
 
+## Version Gate (`__specs__version`)
+
+Before loading a template's context, `template.Get()` runs a pre-flight check against the
+reserved `__specs__version` key in `project.yml`. It lets a template author declare which
+`specs` CLI versions the template supports:
+
+```yaml
+__specs__version: ^0.1.0
+```
+
+The value is any valid [Masterminds/semver](https://github.com/Masterminds/semver) constraint
+string (`0.1.0`, `^0.1.0`, `~0.1.0`, `>= 0.1.0, < 2.0`, …), so both lower and upper bounds can
+be expressed. `template.ExtractSpecsVersion` parses it with `semver.NewConstraint`; the private
+`checkSpecsVersion` helper then evaluates it against the running CLI version (injected via
+`Config.Version` from the cmd layer, so `pkg/template` never imports `pkg/cmd`):
+
+| Condition | Outcome |
+|-----------|---------|
+| Key absent | No check — proceed |
+| Present but not a string, or not a parseable constraint | `ErrInvalidSpecsVersion` — refuse to load |
+| `Config.Version` is empty, `dev`, or otherwise unparseable | Check skipped with a `slog.Debug` line — never lock out source builds |
+| Parsed CLI version does not satisfy the constraint | `ErrSpecsVersionUnsatisfied` (wrapped with `%w`) |
+| Parsed CLI version satisfies the constraint | Proceed |
+
+The gate fires for both `specs use` and `specs template use` (which share `executeTemplate`).
+`specs template save` never calls `Get()`, so a newer template can still be saved on an older
+CLI. The reserved key is consumed during load and never exposed as a template variable.
+
+---
+
 ## Always-ignored files
 
 The following files are silently skipped during rendering, regardless of any other

--- a/docs/content/docs/project-yaml.md
+++ b/docs/content/docs/project-yaml.md
@@ -43,6 +43,27 @@ hooks:
     - go mod tidy
 ```
 
+## Required specs version
+
+Set the reserved `__specs__version` key to declare which `specs` CLI versions a template supports. When present, `specs use` and `specs template use` refuse to run the template unless the running binary satisfies the constraint:
+
+```yaml
+__specs__version: ^0.1.0
+```
+
+The value is any valid [Masterminds/semver](https://github.com/Masterminds/semver) constraint string — both lower and upper bounds are supported:
+
+| Value | Meaning |
+|-------|---------|
+| `0.1.0` | exactly `0.1.0` |
+| `^0.1.0` | `>= 0.1.0, < 0.2.0` |
+| `^1.1.1` | `>= 1.1.1, < 2.0.0` |
+| `~0.1.0` | `>= 0.1.0, < 0.2.0` |
+| `>= 0.1.0` | `>= 0.1.0` |
+| `>= 0.1.0, < 2.0` | explicit range |
+
+A development build (version `dev`, the default when building from source) skips the check so contributors are never locked out. The key is reserved and never exposed as a template variable. `specs template save` intentionally does **not** run the check — you can save a newer template on an older CLI for later use.
+
 ## Computed values
 
 Entries under `computed:` are evaluated after all prompting is complete. They add new keys to the template context and are never shown as prompts. Values may reference user-provided variables.

--- a/docs/content/docs/template-structure.md
+++ b/docs/content/docs/template-structure.md
@@ -45,6 +45,15 @@ __delimiters:
 
 With `[[ ]]` configured, `{{ }}` in your template files passes through unchanged.
 
+## Reserved keys
+
+Keys prefixed with `__` in the project file are reserved by `specs` and are never exposed as template variables:
+
+| Key | Purpose |
+|-----|---------|
+| `__delimiters` | Override the default `{{ }}` delimiters (see above). |
+| `__specs__version` | Declare a semver constraint on the `specs` CLI version required to use the template, e.g. `__specs__version: ^0.1.0`. `specs use` and `specs template use` refuse to run the template when the running binary does not satisfy the constraint (development builds are exempt). See _The project file_ page for accepted constraint shapes. |
+
 ## File permissions
 
 File permission bits are always preserved from template source to output. A script

--- a/internal/cmd/template_use.go
+++ b/internal/cmd/template_use.go
@@ -69,6 +69,9 @@ func newTemplateUseCmd(app *App) *cobra.Command {
 func (a *App) executeTemplate(templateRoot, targetDir string, opts executeOpts) error {
 	cfg := a.templateConfig()
 	cfg.ContinueOnRenderError = opts.continueOnError
+	// Inject the running CLI version so Get() can enforce a template's __specs__version
+	// constraint. Covers both `specs use` and `specs template use`, which share this path.
+	cfg.Version = Version
 	tmpl, err := pkgtemplate.Get(templateRoot, cfg)
 	if err != nil {
 		return err

--- a/internal/cmd/use_test.go
+++ b/internal/cmd/use_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -272,6 +273,45 @@ func TestUse_FailFast_ParseError(t *testing.T) {
 	_, err := executeCmd("use", "--use-defaults", "file:"+srcDir, targetDir)
 	if err == nil {
 		t.Fatal("expected error on parse failure in fail-fast mode, got nil")
+	}
+}
+
+func TestUse_SpecsVersionUnsatisfied(t *testing.T) {
+	// Pin a parseable CLI version so the __specs__version gate actually fires
+	// (the default "dev" build would skip the check).
+	prev := Version
+	Version = "0.1.0"
+	t.Cleanup(func() { Version = prev })
+
+	srcDir := t.TempDir()
+	buildMinimalTemplate(t, srcDir, "Name: world\n__specs__version: ^0.2.0\n", "out.txt", "{{.Name}}")
+	targetDir := t.TempDir()
+
+	_, err := executeCmd("use", "--use-defaults", "file:"+srcDir, targetDir)
+	if !errors.Is(err, specs.ErrSpecsVersionUnsatisfied) {
+		t.Fatalf("expected ErrSpecsVersionUnsatisfied, got %v", err)
+	}
+}
+
+func TestUse_SpecsVersionSatisfied(t *testing.T) {
+	prev := Version
+	Version = "0.1.5"
+	t.Cleanup(func() { Version = prev })
+
+	srcDir := t.TempDir()
+	buildMinimalTemplate(t, srcDir, "Name: world\n__specs__version: ^0.1.0\n", "out.txt", "{{.Name}}")
+	targetDir := t.TempDir()
+
+	_, err := executeCmd("use", "--use-defaults", "file:"+srcDir, targetDir)
+	if err != nil {
+		t.Fatalf("use: expected success when version satisfies constraint, got %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(targetDir, "out.txt"))
+	if err != nil {
+		t.Fatalf("output file missing: %v", err)
+	}
+	if string(got) != "world" {
+		t.Errorf("got %q, want %q", string(got), "world")
 	}
 }
 

--- a/internal/specs/configuration.go
+++ b/internal/specs/configuration.go
@@ -31,6 +31,15 @@ const (
 	//	  left: "[["
 	//	  right: "]]"
 	ProjectDelimitersKey = "__delimiters"
+
+	// ProjectSpecsVersionKey is the reserved project.yaml key that declares a semver
+	// constraint on the specs CLI version required to use the template. Its value must
+	// be a valid Masterminds/semver constraint string (both lower and upper bounds are
+	// supported). The key is consumed during template load and never exposed as a
+	// template variable. Example:
+	//
+	//	__specs__version: ^0.1.0
+	ProjectSpecsVersionKey = "__specs__version"
 )
 
 // ConfigDir returns the specs configuration directory.

--- a/internal/specs/errors.go
+++ b/internal/specs/errors.go
@@ -40,6 +40,15 @@ var (
 	// ErrCyclicDependency is returned when a cycle is detected among computed or
 	// referenced-default keys in project.yaml.
 	ErrCyclicDependency = errors.New("cyclic dependency detected among keys")
+
+	// ErrInvalidSpecsVersion is returned when the reserved "__specs__version" key in
+	// project.yaml is present but is not a string or is not a parseable semver
+	// constraint string.
+	ErrInvalidSpecsVersion = errors.New(`"__specs__version" must be a valid semver constraint string`)
+
+	// ErrSpecsVersionUnsatisfied is returned when the running CLI version does not
+	// satisfy the "__specs__version" constraint declared by the template.
+	ErrSpecsVersionUnsatisfied = errors.New("specs version constraint not satisfied")
 )
 
 // KindOf returns a stable, machine-readable string identifier for the sentinel
@@ -67,6 +76,10 @@ func KindOf(err error) string {
 		return "invalid_computed_def"
 	case errors.Is(err, ErrCyclicDependency):
 		return "cyclic_dependency"
+	case errors.Is(err, ErrInvalidSpecsVersion):
+		return "invalid_specs_version"
+	case errors.Is(err, ErrSpecsVersionUnsatisfied):
+		return "specs_version_unsatisfied"
 	default:
 		return ""
 	}

--- a/internal/specs/errors_test.go
+++ b/internal/specs/errors_test.go
@@ -28,6 +28,10 @@ func TestKindOf_KnownSentinels(t *testing.T) {
 		{fmt.Errorf("%w: key %q conflicts with a user input key", specs.ErrInvalidComputedDef, "foo"), "invalid_computed_def"},
 		{specs.ErrCyclicDependency, "cyclic_dependency"},
 		{fmt.Errorf("%w: a, b", specs.ErrCyclicDependency), "cyclic_dependency"},
+		{specs.ErrInvalidSpecsVersion, "invalid_specs_version"},
+		{fmt.Errorf("%w: got int", specs.ErrInvalidSpecsVersion), "invalid_specs_version"},
+		{specs.ErrSpecsVersionUnsatisfied, "specs_version_unsatisfied"},
+		{fmt.Errorf("%w: template requires specs %s, but this binary is %s", specs.ErrSpecsVersionUnsatisfied, "^0.2.0", "0.1.0"), "specs_version_unsatisfied"},
 	}
 
 	for _, tc := range cases {
@@ -68,6 +72,8 @@ func TestErrorsIs_AllSentinelsWrapCorrectly(t *testing.T) {
 		specs.ErrLocalSource,
 		specs.ErrInvalidComputedDef,
 		specs.ErrCyclicDependency,
+		specs.ErrInvalidSpecsVersion,
+		specs.ErrSpecsVersionUnsatisfied,
 	}
 
 	for _, sentinel := range sentinels {

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -12,6 +12,7 @@ import (
 	texttemplate "text/template"
 	"text/template/parse"
 
+	"github.com/Masterminds/semver/v3"
 	"gopkg.in/yaml.v3"
 
 	"github.com/specsnl/specs-cli/internal/specs"
@@ -34,6 +35,7 @@ func LoadUserContext(templateRoot string, funcMap texttemplate.FuncMap, delims s
 
 	delete(raw, "hooks")                      // consumed by the hook runner, not a template variable
 	delete(raw, specs.ProjectDelimitersKey)   // consumed by Get(); must not appear as a user variable
+	delete(raw, specs.ProjectSpecsVersionKey) // consumed by Get(); must not appear as a user variable
 
 	userCtx, err = resolveReferencedDefaults(raw, funcMap, delims)
 	return userCtx, computedDefs, err
@@ -61,6 +63,30 @@ func ExtractProjectDelimiters(templateRoot string, fallback specs.Delimiters) (s
 		return fallback, specs.ErrInvalidDelimiters
 	}
 	return specs.Delimiters{Left: left, Right: right}, nil
+}
+
+// ExtractSpecsVersion reads project.yaml and returns the semver constraint configured
+// under the __specs__version key, together with the raw constraint string.
+// It returns (nil, "", nil) when the key is absent. It returns ErrInvalidSpecsVersion
+// when the key is present but is not a string or is not a parseable constraint.
+func ExtractSpecsVersion(templateRoot string) (constraint *semver.Constraints, raw string, err error) {
+	rawCtx, err := LoadProjectFile(templateRoot)
+	if err != nil {
+		return nil, "", err
+	}
+	v, ok := rawCtx[specs.ProjectSpecsVersionKey]
+	if !ok {
+		return nil, "", nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return nil, "", fmt.Errorf("%w: got %T", specs.ErrInvalidSpecsVersion, v)
+	}
+	c, err := semver.NewConstraint(s)
+	if err != nil {
+		return nil, "", fmt.Errorf("%w: %q: %v", specs.ErrInvalidSpecsVersion, s, err)
+	}
+	return c, s, nil
 }
 
 // ApplyComputed resolves computed definitions against the finalised context (post-prompt)

--- a/internal/template/context_test.go
+++ b/internal/template/context_test.go
@@ -312,6 +312,74 @@ func TestLoadUserContext_DelimitersKeyStripped(t *testing.T) {
 	}
 }
 
+func TestExtractSpecsVersion_Missing(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\n")
+
+	constraint, raw, err := pkgtemplate.ExtractSpecsVersion(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if constraint != nil {
+		t.Errorf("constraint = %v, want nil when key absent", constraint)
+	}
+	if raw != "" {
+		t.Errorf("raw = %q, want empty when key absent", raw)
+	}
+}
+
+func TestExtractSpecsVersion_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\n__specs__version: ^0.1.0\n")
+
+	constraint, raw, err := pkgtemplate.ExtractSpecsVersion(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if constraint == nil {
+		t.Fatal("constraint = nil, want a parsed constraint")
+	}
+	if raw != "^0.1.0" {
+		t.Errorf("raw = %q, want %q", raw, "^0.1.0")
+	}
+}
+
+func TestExtractSpecsVersion_WrongType(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\n__specs__version: 123\n")
+
+	_, _, err := pkgtemplate.ExtractSpecsVersion(dir)
+	if !errors.Is(err, specs.ErrInvalidSpecsVersion) {
+		t.Errorf("expected ErrInvalidSpecsVersion, got %v", err)
+	}
+}
+
+func TestExtractSpecsVersion_InvalidConstraint(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\n__specs__version: \"not a version\"\n")
+
+	_, _, err := pkgtemplate.ExtractSpecsVersion(dir)
+	if !errors.Is(err, specs.ErrInvalidSpecsVersion) {
+		t.Errorf("expected ErrInvalidSpecsVersion, got %v", err)
+	}
+}
+
+func TestLoadUserContext_SpecsVersionKeyStripped(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\n__specs__version: ^0.1.0\n")
+
+	ctx, _, err := pkgtemplate.LoadUserContext(dir, pkgtemplate.FuncMap(pkgtemplate.Config{}), specs.DefaultDelimiters)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := ctx["__specs__version"]; ok {
+		t.Error("__specs__version should be stripped from user context")
+	}
+	if ctx["Name"] != "test" {
+		t.Errorf("ctx[Name] = %q, want %q", ctx["Name"], "test")
+	}
+}
+
 func TestLoadUserContext_AmbiguousProjectFile(t *testing.T) {
 	dir := t.TempDir()
 	writeProjectYAML(t, dir, "Name: from-yaml\n")

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -13,6 +13,8 @@ import (
 	texttemplate "text/template"
 	"unicode/utf8"
 
+	"github.com/Masterminds/semver/v3"
+
 	"github.com/specsnl/specs-cli/internal/specs"
 )
 
@@ -34,6 +36,12 @@ type Config struct {
 	// Enable this via --continue-on-error when the template has intentionally
 	// unrenderable files that cannot use .specsverbatim.
 	ContinueOnRenderError bool
+
+	// Version is the running specs CLI version, injected by the cmd layer so that
+	// Get() can enforce a template's __specs__version constraint without pkg/template
+	// importing pkg/cmd. An empty value or "dev" (or any otherwise unparseable
+	// version) skips the constraint check.
+	Version string
 }
 
 // delims returns the configured delimiters, falling back to specs.DefaultDelimiters
@@ -62,13 +70,13 @@ type RenderWarning struct {
 
 // Template holds everything needed to execute a boilr template.
 type Template struct {
-	Root         string                 // path to the template root (contains project.yaml + template/)
-	Context      map[string]any         // user input map with referenced defaults resolved
-	ComputedDefs map[string]string      // raw computed definitions; caller must apply via ApplyComputed before Execute
-	Conditionals Conditionals           // varName → Cond; absent means always prompt
-	Referenced   map[string]bool        // schema variables referenced in template files or computed expressions
-	Metadata     *Metadata              // nil if __metadata.json is absent
-	Warnings     []RenderWarning        // non-fatal render issues collected during Execute
+	Root         string            // path to the template root (contains project.yaml + template/)
+	Context      map[string]any    // user input map with referenced defaults resolved
+	ComputedDefs map[string]string // raw computed definitions; caller must apply via ApplyComputed before Execute
+	Conditionals Conditionals      // varName → Cond; absent means always prompt
+	Referenced   map[string]bool   // schema variables referenced in template files or computed expressions
+	Metadata     *Metadata         // nil if __metadata.json is absent
+	Warnings     []RenderWarning   // non-fatal render issues collected during Execute
 	cfg          Config
 	funcMap      texttemplate.FuncMap
 	verbatim     *VerbatimRules
@@ -101,6 +109,12 @@ func Get(templateRoot string, cfg Config) (*Template, error) {
 		return nil, fmt.Errorf("reading delimiters from project file: %w", err)
 	}
 	cfg.Delims = delims
+
+	// Enforce a template-declared __specs__version constraint against the running CLI.
+	// Fires for both `specs use` and `specs template use`; `template save` never calls Get().
+	if err := checkSpecsVersion(templateRoot, cfg.Version); err != nil {
+		return nil, err
+	}
 
 	userCtx, computedDefs, err := LoadUserContext(templateRoot, funcMap, delims)
 	if err != nil {
@@ -144,6 +158,35 @@ func Get(templateRoot string, cfg Config) (*Template, error) {
 		funcMap:      funcMap,
 		verbatim:     verbatim,
 	}, nil
+}
+
+// checkSpecsVersion enforces a __specs__version constraint declared in project.yaml
+// against the running CLI version. It is a no-op when the key is absent.
+//
+// When cliVersion is empty, "dev", or otherwise unparseable, the check is skipped and
+// a debug log is emitted: developers building from source (Version defaults to "dev")
+// must never be locked out. This mirrors how latestSemverTag tolerates unparseable tags.
+func checkSpecsVersion(templateRoot, cliVersion string) error {
+	constraint, raw, err := ExtractSpecsVersion(templateRoot)
+	if err != nil {
+		return err
+	}
+	if constraint == nil {
+		return nil // no constraint declared — nothing to enforce
+	}
+
+	v, err := semver.NewVersion(cliVersion)
+	if err != nil {
+		slog.Debug("skipping specs version check: CLI version is not a parseable semver",
+			"version", cliVersion, "constraint", raw)
+		return nil
+	}
+
+	if !constraint.Check(v) {
+		return fmt.Errorf("%w: template requires specs %s, but this binary is %s",
+			specs.ErrSpecsVersionUnsatisfied, raw, cliVersion)
+	}
+	return nil
 }
 
 // Execute renders the template/ subdirectory into targetDir, which must already exist.

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -1,10 +1,12 @@
 package template_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/specsnl/specs-cli/internal/specs"
 	pkgtemplate "github.com/specsnl/specs-cli/internal/template"
 )
 
@@ -634,6 +636,63 @@ func TestExecute_BinaryDetection_PDFHeader(t *testing.T) {
 	}
 	if string(got) != string(content) {
 		t.Errorf("document.pdf = %q, want verbatim %q (PDF header should be detected as binary even though bytes are valid UTF-8)", got, string(content))
+	}
+}
+
+func TestGet_SpecsVersion_Satisfied(t *testing.T) {
+	root := buildTemplate(t, "Name: World\n__specs__version: ^0.1.0\n", map[string][]byte{
+		"hello.txt": []byte("Hello {{.Name}}"),
+	})
+
+	tmpl, err := pkgtemplate.Get(root, pkgtemplate.Config{Version: "0.1.5"})
+	if err != nil {
+		t.Fatalf("Get: expected success when version satisfies constraint, got %v", err)
+	}
+	// Reserved key must not leak into the context.
+	if _, ok := tmpl.Context["__specs__version"]; ok {
+		t.Error("__specs__version should not appear in the template context")
+	}
+}
+
+func TestGet_SpecsVersion_Unsatisfied(t *testing.T) {
+	root := buildTemplate(t, "Name: World\n__specs__version: ^0.2.0\n", map[string][]byte{
+		"hello.txt": []byte("Hello {{.Name}}"),
+	})
+
+	_, err := pkgtemplate.Get(root, pkgtemplate.Config{Version: "0.1.0"})
+	if !errors.Is(err, specs.ErrSpecsVersionUnsatisfied) {
+		t.Fatalf("Get: expected ErrSpecsVersionUnsatisfied, got %v", err)
+	}
+}
+
+func TestGet_SpecsVersion_SkippedWhenDev(t *testing.T) {
+	root := buildTemplate(t, "Name: World\n__specs__version: ^0.2.0\n", map[string][]byte{
+		"hello.txt": []byte("Hello {{.Name}}"),
+	})
+
+	if _, err := pkgtemplate.Get(root, pkgtemplate.Config{Version: "dev"}); err != nil {
+		t.Fatalf("Get: expected check to be skipped for dev version, got %v", err)
+	}
+}
+
+func TestGet_SpecsVersion_SkippedWhenEmpty(t *testing.T) {
+	root := buildTemplate(t, "Name: World\n__specs__version: ^0.2.0\n", map[string][]byte{
+		"hello.txt": []byte("Hello {{.Name}}"),
+	})
+
+	if _, err := pkgtemplate.Get(root, pkgtemplate.Config{}); err != nil {
+		t.Fatalf("Get: expected check to be skipped for empty version, got %v", err)
+	}
+}
+
+func TestGet_SpecsVersion_Malformed(t *testing.T) {
+	root := buildTemplate(t, "Name: World\n__specs__version: \"not a version\"\n", map[string][]byte{
+		"hello.txt": []byte("Hello {{.Name}}"),
+	})
+
+	_, err := pkgtemplate.Get(root, pkgtemplate.Config{Version: "0.1.0"})
+	if !errors.Is(err, specs.ErrInvalidSpecsVersion) {
+		t.Fatalf("Get: expected ErrInvalidSpecsVersion, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add reserved `__specs__version` key in `project.yaml` so template authors can declare a Masterminds/semver constraint on the required specs CLI version.
- Gate fires in `template.Get()` for `specs use` and `specs template use`; `template save` is exempt. Empty/`dev` (unparseable) versions skip the check so source builds aren't locked out.
- New `ErrInvalidSpecsVersion` / `ErrSpecsVersionUnsatisfied` sentinels wired into `KindOf()` (surface as `error_kind` in JSON output).
- Tests for sentinels, extraction, `Get()` gating, and an end-to-end CLI case; docs + README updated.

Closes #31