### PR TITLE
Reserve the "__" variable namespace for template configuration

### DIFF
--- a/docs/content/docs/architecture/overview.md
+++ b/docs/content/docs/architecture/overview.md
@@ -263,6 +263,7 @@ so that callers can use `errors.Is` to distinguish them:
 | `ErrCyclicDependency` | `cyclic_dependency` | Cycle detected among computed or referenced-default keys |
 | `ErrInvalidSpecsVersion` | `invalid_specs_version` | `__specs__version` in `project.yaml` is not a string or not a parseable semver constraint |
 | `ErrSpecsVersionUnsatisfied` | `specs_version_unsatisfied` | Running CLI version does not satisfy the template's `__specs__version` constraint |
+| `ErrReservedVariableName` | `reserved_variable_name` | A variable or computed name uses the reserved `__` prefix without being a recognised configuration key |
 
 `specs.KindOf(err error) string` returns the stable kind string for any error in the chain,
 or `""` when no known sentinel is wrapped.

--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -70,7 +70,7 @@ __delimiters:
   right: "]]"
 ```
 
-Both `left` and `right` must be non-empty strings. The `__delimiters` key is reserved and never exposed as a template variable.
+Both `left` and `right` must be non-empty strings. The `__delimiters` key is reserved: it is never treated as a user variable (never prompted for, never flagged as unused), but its value is available to templates for reading as `{{ .__delimiters }}` — see below.
 
 ### Reserved `__` namespace
 
@@ -92,6 +92,12 @@ __future: nope   # error: variable names starting with "__" are reserved
 computed:
   __derived: "{{ .Name }}"   # error: computed names are reserved too
 ```
+
+Reserved keys are held out of the schema context (`Template.Context`) so they are never prompted
+for or reported as unused. Their raw values are captured separately in `Template.Reserved` and
+merged into the render context in `Execute`, so templates can read them under their original key —
+e.g. `{{ .__specs__version }}` or `{{ .__delimiters.left }}`. `Validate` also treats these keys
+as defined, so referencing one is never flagged as an unknown variable.
 
 With `[[ ]]` delimiters configured, `{{ }}` in your files passes through unchanged:
 

--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -72,6 +72,25 @@ __delimiters:
 
 Both `left` and `right` must be non-empty strings. The `__delimiters` key is reserved and never exposed as a template variable.
 
+### Reserved `__` namespace
+
+The entire `__` prefix is reserved for specs configuration keys (such as `__delimiters`), so
+that future configuration can be added without clashing with existing template variables.
+A template may **not** define a user variable or a computed value whose name starts with `__`
+unless it is a recognised configuration key. Any other `__`-prefixed name is rejected with
+`ErrReservedVariableName` (`error_kind: reserved_variable_name`).
+
+The check runs whenever a project file is loaded — during `template download`, `template use`
+(and `specs use`), and `template validate` — so a template that misuses the namespace is
+rejected at download time rather than only failing later at execution.
+
+```yaml
+Name: my-project
+__future: nope   # error: variable names starting with "__" are reserved
+computed:
+  __derived: "{{ .Name }}"   # error: computed names are reserved too
+```
+
 With `[[ ]]` delimiters configured, `{{ }}` in your files passes through unchanged:
 
 ```yaml

--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -82,7 +82,9 @@ unless it is a recognised configuration key. Any other `__`-prefixed name is rej
 
 The check runs whenever a project file is loaded — during `template download`, `template use`
 (and `specs use`), and `template validate` — so a template that misuses the namespace is
-rejected at download time rather than only failing later at execution.
+rejected at download time rather than only failing later at execution. Runtime overrides are
+held to the same rule: a reserved name supplied via `--arg __foo=…` or a `--values` file is
+also rejected.
 
 ```yaml
 Name: my-project

--- a/docs/content/docs/template-structure.md
+++ b/docs/content/docs/template-structure.md
@@ -54,6 +54,12 @@ Keys prefixed with `__` in the project file are reserved by `specs` and are neve
 | `__delimiters` | Override the default `{{ }}` delimiters (see above). |
 | `__specs__version` | Declare a semver constraint on the `specs` CLI version required to use the template, e.g. `__specs__version: ^0.1.0`. `specs use` and `specs template use` refuse to run the template when the running binary does not satisfy the constraint (development builds are exempt). See _The project file_ page for accepted constraint shapes. |
 
+The whole `__` namespace is reserved. You cannot define a variable or computed value whose name
+starts with `__` unless it is one of the recognised configuration keys above. Doing so makes
+`specs template download`, `specs template use`, and `specs template validate` fail with a
+"reserved" error, keeping the namespace free for future configuration. The same rule applies to
+values passed at run time via `--arg` or a `--values` file.
+
 ## File permissions
 
 File permission bits are always preserved from template source to output. A script

--- a/docs/content/docs/template-structure.md
+++ b/docs/content/docs/template-structure.md
@@ -60,6 +60,10 @@ starts with `__` unless it is one of the recognised configuration keys above. Do
 "reserved" error, keeping the namespace free for future configuration. The same rule applies to
 values passed at run time via `--arg` or a `--values` file.
 
+Even though they are reserved, the recognised keys' values are made available to your templates
+under their original name, so you can reference them directly — for example
+`{{ .__specs__version }}` or `{{ .__delimiters.left }}`.
+
 ## File permissions
 
 File permission bits are always preserved from template source to output. A script

--- a/internal/cmd/template_download.go
+++ b/internal/cmd/template_download.go
@@ -52,6 +52,15 @@ func newTemplateDownloadCmd(app *App) *cobra.Command {
 				return err
 			}
 
+			// Reject templates that use the reserved "__" variable namespace. Remove the
+			// freshly cloned directory so a rejected template is not left registered.
+			if raw, perr := pkgtemplate.LoadProjectFile(dest); perr == nil {
+				if err := pkgtemplate.CheckReservedNames(raw); err != nil {
+					_ = os.RemoveAll(dest)
+					return err
+				}
+			}
+
 			// When no branch was specified, resolve the actual checked-out branch so that
 			// future update/upgrade checks can compare against the correct remote ref.
 			branch := src.Branch

--- a/internal/cmd/template_use.go
+++ b/internal/cmd/template_use.go
@@ -99,6 +99,9 @@ func (a *App) executeTemplate(templateRoot, targetDir string, opts executeOpts) 
 			return err
 		}
 		for k := range fileVals {
+			if specs.IsReservedName(k) {
+				return fmt.Errorf("%w: %q (from --values)", specs.ErrReservedVariableName, k)
+			}
 			provided[k] = true
 			finalSource[k] = "values_file"
 		}
@@ -109,6 +112,9 @@ func (a *App) executeTemplate(templateRoot, targetDir string, opts executeOpts) 
 		k, v, err := values.ParseArg(pair)
 		if err != nil {
 			return err
+		}
+		if specs.IsReservedName(k) {
+			return fmt.Errorf("%w: %q (from --arg)", specs.ErrReservedVariableName, k)
 		}
 		ctx[k] = v
 		provided[k] = true

--- a/internal/cmd/template_use_test.go
+++ b/internal/cmd/template_use_test.go
@@ -121,6 +121,46 @@ func TestTemplateUse_ArgBeatsValues(t *testing.T) {
 	}
 }
 
+func TestTemplateUse_ReservedArgRejected(t *testing.T) {
+	withTempRegistry(t)
+	src := makeTemplateWithVar(t, "Name", "default")
+	target := t.TempDir()
+
+	err := saveAndUse(t, src, "tpl", target, "--use-defaults", "--arg", "__foo=bar")
+	if !errors.Is(err, specs.ErrReservedVariableName) {
+		t.Fatalf("expected ErrReservedVariableName, got %v", err)
+	}
+}
+
+func TestTemplateUse_ReservedValuesFileRejected(t *testing.T) {
+	withTempRegistry(t)
+	src := makeTemplateWithVar(t, "Name", "default")
+
+	vf := filepath.Join(t.TempDir(), "vals.json")
+	data, _ := json.Marshal(map[string]string{"__foo": "bar"})
+	if err := os.WriteFile(vf, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	target := t.TempDir()
+	err := saveAndUse(t, src, "tpl", target, "--use-defaults", "--values", vf)
+	if !errors.Is(err, specs.ErrReservedVariableName) {
+		t.Fatalf("expected ErrReservedVariableName, got %v", err)
+	}
+}
+
+func TestTemplateUse_DelimitersArgAllowed(t *testing.T) {
+	// __delimiters is a recognised configuration key, so it is not rejected as a
+	// reserved variable when passed via --arg (though as an arg it is inert).
+	withTempRegistry(t)
+	src := makeTemplateWithVar(t, "Name", "default")
+	target := t.TempDir()
+
+	if err := saveAndUse(t, src, "tpl", target, "--use-defaults", "--arg", "__delimiters=x"); err != nil {
+		t.Fatalf("template use: %v", err)
+	}
+}
+
 func TestTemplateUse_NotFound(t *testing.T) {
 	withTempRegistry(t)
 	_, err := executeCmd("template", "use", "--use-defaults", "no-such-name", t.TempDir())

--- a/internal/cmd/template_use_test.go
+++ b/internal/cmd/template_use_test.go
@@ -121,6 +121,36 @@ func TestTemplateUse_ArgBeatsValues(t *testing.T) {
 	}
 }
 
+func TestTemplateUse_ReservedValueRenderedIntoOutput(t *testing.T) {
+	// Reserved config values are stripped from the schema but still available to templates.
+	withTempRegistry(t)
+
+	dir := t.TempDir()
+	tmplDir := filepath.Join(dir, specs.TemplateDirFile)
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	project := "Name: demo\n__specs__version: \">=0.0.1\"\n"
+	if err := os.WriteFile(filepath.Join(dir, specs.ProjectYAMLFile), []byte(project), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmplDir, "out.txt"), []byte("v={{ .__specs__version }}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	target := t.TempDir()
+	if err := saveAndUse(t, dir, "tpl", target, "--use-defaults"); err != nil {
+		t.Fatalf("template use: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(target, "out.txt"))
+	if err != nil {
+		t.Fatalf("output file missing: %v", err)
+	}
+	if string(got) != "v=>=0.0.1" {
+		t.Errorf("got %q, want %q", string(got), "v=>=0.0.1")
+	}
+}
+
 func TestTemplateUse_ReservedArgRejected(t *testing.T) {
 	withTempRegistry(t)
 	src := makeTemplateWithVar(t, "Name", "default")

--- a/internal/cmd/template_validate_test.go
+++ b/internal/cmd/template_validate_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/specsnl/specs-cli/internal/specs"
 	"github.com/specsnl/specs-cli/internal/util/exit"
 )
 
@@ -16,6 +17,19 @@ func TestValidate_ValidTemplate(t *testing.T) {
 
 	if _, err := executeCmd("template", "validate", src); err != nil {
 		t.Fatalf("template validate: %v", err)
+	}
+}
+
+func TestValidate_ReservedVariableName(t *testing.T) {
+	withTempRegistry(t)
+	src := makeValidateTemplate(t,
+		"Name: \"\"\n__future: \"nope\"\n",
+		map[string]string{"README.md": "# {{ .Name }}\n"},
+	)
+
+	_, err := executeCmd("template", "validate", src)
+	if !errors.Is(err, specs.ErrReservedVariableName) {
+		t.Fatalf("expected ErrReservedVariableName, got %v", err)
 	}
 }
 

--- a/internal/cmd/template_validate_test.go
+++ b/internal/cmd/template_validate_test.go
@@ -33,6 +33,20 @@ func TestValidate_ReservedVariableName(t *testing.T) {
 	}
 }
 
+func TestValidate_ReservedValueReferenceIsKnown(t *testing.T) {
+	// Referencing a reserved config value (exposed to templates) must not be reported as an
+	// unknown variable, and the template must validate cleanly.
+	withTempRegistry(t)
+	src := makeValidateTemplate(t,
+		"Name: \"\"\n__specs__version: \">=0.0.1\"\n",
+		map[string]string{"README.md": "# {{ .Name }} needs specs {{ .__specs__version }}\n"},
+	)
+
+	if _, err := executeCmd("template", "validate", src); err != nil {
+		t.Fatalf("expected clean validation, got %v", err)
+	}
+}
+
 func TestValidate_MissingTemplateDir(t *testing.T) {
 	withTempRegistry(t)
 

--- a/internal/specs/configuration.go
+++ b/internal/specs/configuration.go
@@ -3,6 +3,7 @@ package specs
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/adrg/xdg"
 )
@@ -40,7 +41,26 @@ const (
 	//
 	//	__specs__version: ^0.1.0
 	ProjectSpecsVersionKey = "__specs__version"
+
+	// ReservedKeyPrefix marks project.yaml keys that carry specs configuration rather
+	// than user variables. The whole namespace is reserved so future configuration keys
+	// can be added without clashing with existing template variables; templates may not
+	// define variables (or computed values) with this prefix.
+	ReservedKeyPrefix = "__"
 )
+
+// ReservedConfigKeys is the set of recognised __-prefixed keys that carry configuration.
+// Any other __-prefixed key in a project file is rejected via ErrReservedVariableName.
+var ReservedConfigKeys = map[string]bool{
+	ProjectDelimitersKey:   true,
+	ProjectSpecsVersionKey: true,
+}
+
+// IsReservedName reports whether name uses the reserved __ prefix without being a
+// recognised configuration key. Such names may not be used as template variables.
+func IsReservedName(name string) bool {
+	return strings.HasPrefix(name, ReservedKeyPrefix) && !ReservedConfigKeys[name]
+}
 
 // ConfigDir returns the specs configuration directory.
 // Defaults to $XDG_CONFIG_HOME/specs (~/.config/specs).

--- a/internal/specs/configuration_test.go
+++ b/internal/specs/configuration_test.go
@@ -34,3 +34,23 @@ func TestTemplateDir_XDGOverride(t *testing.T) {
 	}
 }
 
+func TestIsReservedName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"name", false},
+		{"_private", false},
+		{"__delimiters", false}, // recognised configuration key
+		{"__foo", true},
+		{"__", true},
+		{"__custom_config", true},
+	}
+
+	for _, tc := range cases {
+		if got := specs.IsReservedName(tc.name); got != tc.want {
+			t.Errorf("IsReservedName(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+

--- a/internal/specs/errors.go
+++ b/internal/specs/errors.go
@@ -49,6 +49,12 @@ var (
 	// ErrSpecsVersionUnsatisfied is returned when the running CLI version does not
 	// satisfy the "__specs__version" constraint declared by the template.
 	ErrSpecsVersionUnsatisfied = errors.New("specs version constraint not satisfied")
+
+	// ErrReservedVariableName is returned when a template defines a variable
+	// (top-level key or computed value) whose name starts with the reserved "__"
+	// prefix. That namespace is reserved for specs configuration keys such as
+	// __delimiters.
+	ErrReservedVariableName = errors.New(`variable names starting with "__" are reserved for specs configuration`)
 )
 
 // KindOf returns a stable, machine-readable string identifier for the sentinel
@@ -80,6 +86,8 @@ func KindOf(err error) string {
 		return "invalid_specs_version"
 	case errors.Is(err, ErrSpecsVersionUnsatisfied):
 		return "specs_version_unsatisfied"
+	case errors.Is(err, ErrReservedVariableName):
+		return "reserved_variable_name"
 	default:
 		return ""
 	}

--- a/internal/specs/errors_test.go
+++ b/internal/specs/errors_test.go
@@ -32,6 +32,8 @@ func TestKindOf_KnownSentinels(t *testing.T) {
 		{fmt.Errorf("%w: got int", specs.ErrInvalidSpecsVersion), "invalid_specs_version"},
 		{specs.ErrSpecsVersionUnsatisfied, "specs_version_unsatisfied"},
 		{fmt.Errorf("%w: template requires specs %s, but this binary is %s", specs.ErrSpecsVersionUnsatisfied, "^0.2.0", "0.1.0"), "specs_version_unsatisfied"},
+		{specs.ErrReservedVariableName, "reserved_variable_name"},
+		{fmt.Errorf("%w: __foo", specs.ErrReservedVariableName), "reserved_variable_name"},
 	}
 
 	for _, tc := range cases {
@@ -74,6 +76,7 @@ func TestErrorsIs_AllSentinelsWrapCorrectly(t *testing.T) {
 		specs.ErrCyclicDependency,
 		specs.ErrInvalidSpecsVersion,
 		specs.ErrSpecsVersionUnsatisfied,
+		specs.ErrReservedVariableName,
 	}
 
 	for _, sentinel := range sentinels {

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -94,6 +94,25 @@ func ExtractSpecsVersion(templateRoot string) (constraint *semver.Constraints, r
 	return c, s, nil
 }
 
+// ReservedValues reads the project file and returns the values of the recognised reserved
+// configuration keys (e.g. __delimiters, __specs__version) that are present. These are the
+// only __-prefixed keys allowed in a project file — CheckReservedNames rejects any others —
+// and their values are made available to templates under their original key during rendering.
+// Returns an empty (non-nil) map when no reserved key is present.
+func ReservedValues(templateRoot string) (map[string]any, error) {
+	raw, err := LoadProjectFile(templateRoot)
+	if err != nil {
+		return nil, err
+	}
+	reserved := make(map[string]any)
+	for k := range specs.ReservedConfigKeys {
+		if v, ok := raw[k]; ok {
+			reserved[k] = v
+		}
+	}
+	return reserved, nil
+}
+
 // ApplyComputed resolves computed definitions against the finalised context (post-prompt)
 // and returns a new map containing both user inputs and computed values.
 // Called after prompting and --values/--arg overrides are complete.

--- a/internal/template/context.go
+++ b/internal/template/context.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	texttemplate "text/template"
 	"text/template/parse"
@@ -25,6 +26,10 @@ import (
 func LoadUserContext(templateRoot string, funcMap texttemplate.FuncMap, delims specs.Delimiters) (userCtx map[string]any, computedDefs map[string]string, err error) {
 	raw, err := LoadProjectFile(templateRoot)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := CheckReservedNames(raw); err != nil {
 		return nil, nil, err
 	}
 
@@ -174,6 +179,39 @@ func LoadProjectFile(templateRoot string) (map[string]any, error) {
 		return nil, fmt.Errorf("parsing %s: %w", specs.ProjectJSONFile, err)
 	}
 	return ctx, nil
+}
+
+// CheckReservedNames returns ErrReservedVariableName if raw defines any variable whose
+// name uses the reserved "__" prefix without being a recognised configuration key (such
+// as __delimiters). Both top-level keys and computed value names are checked, since both
+// become template context keys. The "__" namespace is reserved so future specs
+// configuration keys can be added without clashing with existing template variables.
+func CheckReservedNames(raw map[string]any) error {
+	seen := make(map[string]bool)
+	var offending []string
+	collect := func(name string) {
+		if specs.IsReservedName(name) && !seen[name] {
+			seen[name] = true
+			offending = append(offending, name)
+		}
+	}
+
+	for k, v := range raw {
+		collect(k)
+		if k == "computed" {
+			if m, ok := v.(map[string]any); ok {
+				for ck := range m {
+					collect(ck)
+				}
+			}
+		}
+	}
+
+	if len(offending) == 0 {
+		return nil
+	}
+	sort.Strings(offending)
+	return fmt.Errorf("%w: %s", specs.ErrReservedVariableName, strings.Join(offending, ", "))
 }
 
 // extractComputed removes the "computed" key from raw and returns its string entries.

--- a/internal/template/context_test.go
+++ b/internal/template/context_test.go
@@ -409,6 +409,38 @@ func TestLoadUserContext_DelimitersKeyNotReserved(t *testing.T) {
 	}
 }
 
+func TestReservedValues(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: demo\n__specs__version: \">=0.0.1\"\n__delimiters:\n  left: \"[[\"\n  right: \"]]\"\n")
+
+	reserved, err := pkgtemplate.ReservedValues(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if reserved["__specs__version"] != ">=0.0.1" {
+		t.Errorf("reserved[__specs__version] = %v, want %q", reserved["__specs__version"], ">=0.0.1")
+	}
+	if _, ok := reserved["__delimiters"]; !ok {
+		t.Error("reserved should contain __delimiters")
+	}
+	if _, ok := reserved["Name"]; ok {
+		t.Error("reserved must not contain non-reserved user keys")
+	}
+}
+
+func TestReservedValues_None(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: demo\n")
+
+	reserved, err := pkgtemplate.ReservedValues(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(reserved) != 0 {
+		t.Errorf("reserved = %v, want empty", reserved)
+	}
+}
+
 func TestCheckReservedNames(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/template/context_test.go
+++ b/internal/template/context_test.go
@@ -380,6 +380,62 @@ func TestLoadUserContext_SpecsVersionKeyStripped(t *testing.T) {
 	}
 }
 
+func TestLoadUserContext_ReservedVariableName(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\n__future: nope\n")
+
+	_, _, err := pkgtemplate.LoadUserContext(dir, pkgtemplate.FuncMap(pkgtemplate.Config{}), specs.DefaultDelimiters)
+	if !errors.Is(err, specs.ErrReservedVariableName) {
+		t.Fatalf("expected ErrReservedVariableName, got %v", err)
+	}
+}
+
+func TestLoadUserContext_ReservedComputedName(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\ncomputed:\n  __derived: \"{{ .Name }}\"\n")
+
+	_, _, err := pkgtemplate.LoadUserContext(dir, pkgtemplate.FuncMap(pkgtemplate.Config{}), specs.DefaultDelimiters)
+	if !errors.Is(err, specs.ErrReservedVariableName) {
+		t.Fatalf("expected ErrReservedVariableName, got %v", err)
+	}
+}
+
+func TestLoadUserContext_DelimitersKeyNotReserved(t *testing.T) {
+	dir := t.TempDir()
+	writeProjectYAML(t, dir, "Name: test\n__delimiters:\n  left: \"[[\"\n  right: \"]]\"\n")
+
+	if _, _, err := pkgtemplate.LoadUserContext(dir, pkgtemplate.FuncMap(pkgtemplate.Config{}), specs.DefaultDelimiters); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckReservedNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     map[string]any
+		wantErr bool
+	}{
+		{"no reserved keys", map[string]any{"Name": "x", "hooks": map[string]any{}}, false},
+		{"delimiters allowed", map[string]any{"__delimiters": map[string]any{"left": "[["}}, false},
+		{"specs version allowed", map[string]any{"__specs__version": "^0.1.0"}, false},
+		{"reserved top-level", map[string]any{"__foo": "bar"}, true},
+		{"reserved computed", map[string]any{"computed": map[string]any{"__c": "x"}}, true},
+		{"computed non-mapping ignored", map[string]any{"computed": "not-a-map"}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := pkgtemplate.CheckReservedNames(tc.raw)
+			if tc.wantErr && !errors.Is(err, specs.ErrReservedVariableName) {
+				t.Fatalf("expected ErrReservedVariableName, got %v", err)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadUserContext_AmbiguousProjectFile(t *testing.T) {
 	dir := t.TempDir()
 	writeProjectYAML(t, dir, "Name: from-yaml\n")

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -75,6 +76,7 @@ type Template struct {
 	ComputedDefs map[string]string // raw computed definitions; caller must apply via ApplyComputed before Execute
 	Conditionals Conditionals      // varName → Cond; absent means always prompt
 	Referenced   map[string]bool   // schema variables referenced in template files or computed expressions
+	Reserved     map[string]any    // recognised reserved config values (e.g. __delimiters), exposed to templates during rendering
 	Metadata     *Metadata         // nil if __metadata.json is absent
 	Warnings     []RenderWarning   // non-fatal render issues collected during Execute
 	cfg          Config
@@ -121,6 +123,13 @@ func Get(templateRoot string, cfg Config) (*Template, error) {
 		return nil, err
 	}
 
+	// Reserved config keys are stripped from userCtx but their values are still made
+	// available to templates under their original key (e.g. {{ .__specs__version }}).
+	reserved, err := ReservedValues(templateRoot)
+	if err != nil {
+		return nil, err
+	}
+
 	conds, referenced, err := AnalyzeConditionals(templateRoot, userCtx, funcMap, delims)
 	if err != nil {
 		return nil, err
@@ -153,6 +162,7 @@ func Get(templateRoot string, cfg Config) (*Template, error) {
 		ComputedDefs: computedDefs,
 		Conditionals: conds,
 		Referenced:   referenced,
+		Reserved:     reserved,
 		Metadata:     meta,
 		cfg:          cfg,
 		funcMap:      funcMap,
@@ -194,6 +204,16 @@ func checkSpecsVersion(templateRoot, cliVersion string) error {
 // ApplyComputed before Execute when ComputedDefs are present.
 func (t *Template) Execute(targetDir string) error {
 	ctx := t.Context
+	// Expose recognised reserved config values (e.g. __delimiters, __specs__version) to
+	// templates. They are kept out of Context so they are never prompted for or flagged as
+	// unused, so merge them into a copy of the render context here. User/computed values can
+	// never collide with these keys — CheckReservedNames forbids user __ keys.
+	if len(t.Reserved) > 0 {
+		merged := make(map[string]any, len(ctx)+len(t.Reserved))
+		maps.Copy(merged, ctx)
+		maps.Copy(merged, t.Reserved)
+		ctx = merged
+	}
 
 	srcRoot := filepath.Join(t.Root, specs.TemplateDirFile)
 

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -329,6 +329,56 @@ func TestExecute_CustomDelimiters_NotInContext(t *testing.T) {
 	}
 }
 
+func TestExecute_ReservedSpecsVersionAvailable(t *testing.T) {
+	// A recognised reserved config key is stripped from the schema context but its value
+	// is still made available to templates under its original key during rendering.
+	root := buildTemplate(t,
+		"Name: demo\n__specs__version: \">=0.0.1\"\n",
+		map[string][]byte{"out.txt": []byte("v={{ .__specs__version }}")},
+	)
+
+	tmpl, err := pkgtemplate.Get(root, pkgtemplate.Config{})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if _, ok := tmpl.Context["__specs__version"]; ok {
+		t.Error("__specs__version should not appear in the schema context")
+	}
+	if tmpl.Reserved["__specs__version"] != ">=0.0.1" {
+		t.Errorf("Reserved[__specs__version] = %v, want %q", tmpl.Reserved["__specs__version"], ">=0.0.1")
+	}
+
+	target := t.TempDir()
+	if err := tmpl.Execute(target); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := readFile(t, target, "out.txt"); got != "v=>=0.0.1" {
+		t.Errorf("out.txt = %q, want %q", got, "v=>=0.0.1")
+	}
+}
+
+func TestExecute_ReservedDelimitersAvailable(t *testing.T) {
+	// The __delimiters mapping is available to templates as nested fields, rendered with
+	// the very delimiters it configures.
+	yaml := "Name: demo\n__delimiters:\n  left: \"[[\"\n  right: \"]]\"\n"
+	root := buildTemplate(t, yaml, map[string][]byte{
+		"out.txt": []byte("d=[[ .__delimiters.left ]][[ .__delimiters.right ]]"),
+	})
+
+	tmpl, err := pkgtemplate.Get(root, pkgtemplate.Config{})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	target := t.TempDir()
+	if err := tmpl.Execute(target); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := readFile(t, target, "out.txt"); got != "d=[[]]" {
+		t.Errorf("out.txt = %q, want %q", got, "d=[[]]")
+	}
+}
+
 func TestGet_InvalidDelimiters_ReturnsError(t *testing.T) {
 	// __delimiters present but malformed — Get must return an error.
 	yaml := "__delimiters: not-a-mapping\nName: x\n"

--- a/internal/template/validate.go
+++ b/internal/template/validate.go
@@ -63,11 +63,16 @@ func HasUnused(issues []ValidationIssue) bool {
 //     is never referenced in any template file, path expression, or computed
 //     expression.
 func (t *Template) Validate() ([]ValidationIssue, error) {
-	allDefined := make(map[string]bool, len(t.Context)+len(t.ComputedDefs))
+	allDefined := make(map[string]bool, len(t.Context)+len(t.ComputedDefs)+len(t.Reserved))
 	for k := range t.Context {
 		allDefined[k] = true
 	}
 	for k := range t.ComputedDefs {
+		allDefined[k] = true
+	}
+	// Reserved config values (e.g. __delimiters, __specs__version) are exposed to templates
+	// during rendering, so a reference to one is a known variable — not an unknown.
+	for k := range t.Reserved {
 		allDefined[k] = true
 	}
 


### PR DESCRIPTION
## Summary
- Reserve the `__` prefix for specs configuration keys (like `__delimiters`); templates may no longer define variables or computed values with that prefix.
- Enforce it wherever a project file is loaded — `template download`, `template use`/`specs use`, and `template validate` — so bad templates fail at download time, not only at execution.
- Apply the same rule to runtime overrides supplied via `--arg` and `--values`.
- Add `specs.ErrReservedVariableName` (kind: `reserved_variable_name`), unit + command-level tests, and user/architecture docs.

Closes #32