### PR TITLE
Add markdown lint CI workflow and format markdown

### DIFF
--- a/.github/instructions/executing-commands.md
+++ b/.github/instructions/executing-commands.md
@@ -11,11 +11,13 @@ applyTo: "**"
 Use the Taskfile tasks for building and testing. Other commands (e.g. `git`, file manipulation,
 installing host tools) may run locally on the host.
 
-| Operation         | How to run              |
-| ----------------- | ----------------------- |
-| Run tests         | `task test`             |
-| Build the binary  | `task build`            |
-| Anything else     | Run locally on the host |
+| Operation                           | How to run              |
+|-------------------------------------|-------------------------|
+| Run tests                           | `task test`             |
+| Build the binary                    | `task build`            |
+| Check Markdown style                | `task md:check`         |
+| Fix Markdown (tables + autofixable) | `task md:fix`           |
+| Anything else                       | Run locally on the host |
 
 Never call `docker` or `docker compose` directly — use the Taskfile tasks above.
 
@@ -30,6 +32,10 @@ task --list
 `task test` and `task build` execute inside the `go-builder` Docker Compose service. This
 service is a one-off container (`--rm`) under the `build` profile — it does not need to be
 started before use.
+
+`task md:check` and `task md:fix` run `markdownlint-cli2` (and, for fixes,
+`markdown-table-formatter`) inside the `node` Docker Compose service under the `markdown`
+profile. The same checks run in CI via `.github/workflows/md.yml`.
 
 Do not use `task dc:run:go-builder` unless no suitable task exists for the operation. Prefer
 creating or extending a task in `Taskfile.dist.yml` instead.

--- a/.github/instructions/executing-commands.md
+++ b/.github/instructions/executing-commands.md
@@ -11,11 +11,11 @@ applyTo: "**"
 Use the Taskfile tasks for building and testing. Other commands (e.g. `git`, file manipulation,
 installing host tools) may run locally on the host.
 
-| Operation | How to run |
-|-----------|-----------|
-| Run tests | `task test` |
-| Build the binary | `task build` |
-| Anything else | Run locally on the host |
+| Operation         | How to run              |
+| ----------------- | ----------------------- |
+| Run tests         | `task test`             |
+| Build the binary  | `task build`            |
+| Anything else     | Run locally on the host |
 
 Never call `docker` or `docker compose` directly — use the Taskfile tasks above.
 

--- a/.github/workflows/md.yml
+++ b/.github/workflows/md.yml
@@ -1,0 +1,57 @@
+name: Markdown
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    name: Changes Filter
+    runs-on: ubuntu-24.04
+    outputs:
+      mdlint: ${{ steps.filter.outputs.mdlint }}
+    steps:
+      - name: Checkout
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            mdlint:
+              - '**.md'
+              - '.markdownlint-cli2.yaml'
+              - '.github/workflows/md.yml'
+
+  mdlint:
+    name: Check markdown style
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.mdlint == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Lint Markdown files
+        uses: DavidAnson/markdownlint-cli2-action@v23
+
+  gate-mdlint:
+    name: Markdown gate
+    runs-on: ubuntu-24.04
+    needs: [changes, mdlint]
+    if: always()
+    steps:
+      - run: exit 1
+        if: needs.changes.result != 'success' || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      - run: exit 0

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,27 @@
+# CLI config: https://github.com/DavidAnson/markdownlint-cli2?tab=readme-ov-file#markdownlint-cli2jsonc
+# Lint rules: https://github.com/DavidAnson/markdownlint?tab=readme-ov-file#rules--aliases
+
+config:
+  line-length:
+    line_length: 1000
+    tables: false
+  no-inline-html:
+    allowed_elements:
+      - dl
+      - dt
+      - dd
+      - details
+      - summary
+      - code
+  ul-style:
+    style: dash
+  # README opens with a centred HTML header and CLAUDE.md with an @import
+  # directive, so neither starts with a Markdown H1.
+  first-line-heading: false
+
+globs:
+  - '**/*.md'
+  - '!internal/testdata'
+
+gitignore: true
+showFound: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,10 @@
 
 Architecture documentation lives in the `docs/` directory.
 
-| File | Description |
-|------|-------------|
-| [docs/content/docs/architecture/overview.md](./docs/content/docs/architecture/overview.md) | Package structure, CLI tree, data flows |
-| [docs/content/docs/architecture/template-engine.md](./docs/content/docs/architecture/template-engine.md) | Template engine: delimiters, verbatim copy, conditional files, file permissions, hooks |
-| [docs/content/docs/architecture/computed-values.md](./docs/content/docs/architecture/computed-values.md) | Computed values: post-prompt derived context keys |
-| [docs/content/docs/architecture/library-decisions.md](./docs/content/docs/architecture/library-decisions.md) | Library choices and rationale |
-| [docs/operations/release.md](./docs/operations/release.md) | Release pipeline: GoReleaser, GitHub Releases, Homebrew, CI/CD |
+| File                                                                                                         | Description                                                                            |
+|--------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| [docs/content/docs/architecture/overview.md](./docs/content/docs/architecture/overview.md)                   | Package structure, CLI tree, data flows                                                |
+| [docs/content/docs/architecture/template-engine.md](./docs/content/docs/architecture/template-engine.md)     | Template engine: delimiters, verbatim copy, conditional files, file permissions, hooks |
+| [docs/content/docs/architecture/computed-values.md](./docs/content/docs/architecture/computed-values.md)     | Computed values: post-prompt derived context keys                                      |
+| [docs/content/docs/architecture/library-decisions.md](./docs/content/docs/architecture/library-decisions.md) | Library choices and rationale                                                          |
+| [docs/operations/release.md](./docs/operations/release.md)                                                   | Release pipeline: GoReleaser, GitHub Releases, Homebrew, CI/CD                         |

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ specs template use my-template ./my-project
 
 A template's `project.yml` declares its variables, defaults, computed values, and hooks. A few `__`-prefixed keys are reserved by `specs` and never exposed as template variables:
 
-| Key | Purpose |
-|-----|---------|
-| `__delimiters` | Override the default `{{ }}` template delimiters with a custom pair (e.g. `[[ ]]`). |
+| Key                | Purpose                                                                                                                                                                                                                                                                                                                                                   |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `__delimiters`     | Override the default `{{ }}` template delimiters with a custom pair (e.g. `[[ ]]`).                                                                                                                                                                                                                                                                       |
 | `__specs__version` | Declare a [semver](https://github.com/Masterminds/semver) constraint on the `specs` CLI version required to use the template, e.g. `__specs__version: ^0.1.0`. `specs use` and `specs template use` refuse to run the template unless the running binary satisfies the constraint (development builds are exempt; `specs template save` skips the check). |
 
 See the [documentation](https://cli.specs.dev) for the full project-file reference.
@@ -62,10 +62,10 @@ See the [documentation](https://cli.specs.dev) for the full project-file referen
 
 The repo ships a `Dockerfile` and a `compose.yml` that together define a self-contained build and test environment. Contributors don't need a local Go installation — all builds and tests run inside a Docker container that pins the exact Go version and tooling.
 
-| File | Role |
-|------|------|
-| `Dockerfile` | Defines the build image — Go 1.26 + tooling, used by `task build` and `task test` |
-| `compose.yml` | Wires the Dockerfile stages into named services consumed by the Taskfile |
+| File                | Role                                                                                     |
+|---------------------|------------------------------------------------------------------------------------------|
+| `Dockerfile`        | Defines the build image — Go 1.26 + tooling, used by `task build` and `task test`        |
+| `compose.yml`       | Wires the Dockerfile stages into named services consumed by the Taskfile                 |
 | `Taskfile.dist.yml` | Orchestrates all developer workflows; wraps Docker Compose so you never call it directly |
 
 **Requirements:** [Task](https://taskfile.dev) and Docker.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+<!-- markdownlint-disable MD033 -->
 <p align="center">
   <img src="docs/static/logo.svg" width="200" alt="Specs CLI">
   <h1 align="center">Specs CLI</h1>
   <p align="center"><strong>Documentation:</strong> <a href="https://cli.specs.dev">cli.specs.dev</a></p>
 </p>
+<!-- markdownlint-enable MD033 -->
 
 A general-purpose developer CLI for scaffolding projects from templates. Define variables, write template files, run hooks — `specs` handles the rest.
 

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -119,6 +119,29 @@ tasks:
         vars:
           SUB_CMD: mod tidy
 
+  md:check:
+    desc: Check the style of Markdown files with markdownlint
+    cmds:
+      - task: dc:run:node
+        vars:
+          SUB_CMD: "npx --yes markdownlint-cli2 {{.SUB_CMD}}"
+
+  md:fix:
+    desc: Fix Markdown style — align tables, then apply autofixable lint rules
+    cmds:
+      - task: md:fix-tables
+      - task: md:check
+        vars:
+          SUB_CMD: --fix
+
+  md:fix-tables:
+    desc: Align table spacing in Markdown files
+    cmds:
+      # dotglob so hidden directories (e.g. .github) are covered too.
+      - task: dc:run:node
+        vars:
+          SUB_CMD: bash -c "shopt -s globstar dotglob && npx --yes markdown-table-formatter **/*.md"
+
   cleanup:
     desc: Cleanup workspace
     summary: |

--- a/compose.yml
+++ b/compose.yml
@@ -51,3 +51,11 @@ services:
       - ./docs/nginx.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
       - "8080:80"
+
+  node:
+    profiles: ["markdown"]
+    # Latest version: https://hub.docker.com/_/node/tags
+    image: node:24.15.0-bookworm
+    working_dir: /src
+    volumes:
+      - .:/src

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -3,6 +3,8 @@ title: Specs CLI
 layout: hextra-home
 ---
 
+<!-- markdownlint-disable MD033 -->
+
 <div class="hx-mt-6 hx-mb-6">
 {{< hextra/hero-headline >}}
   Scaffold projects from templates

--- a/docs/content/docs/architecture/computed-values.md
+++ b/docs/content/docs/architecture/computed-values.md
@@ -6,6 +6,7 @@ weight: 3
 ## Problem
 
 There is no way to define a value that is:
+
 - Always derived from other inputs (never prompted)
 - Available in template files under a clean name
 - Composed of hardcoded strings, Sprout functions, and references to user-provided inputs
@@ -19,6 +20,7 @@ are purely derived.
 ## Decision
 
 Add a top-level `computed:` section to `project.yml`. Keys in `computed:` are:
+
 - Evaluated **after** all user inputs are finalised (post-prompt)
 - **Never** shown as prompts
 - **Not** overridable via `--values` or `--arg`
@@ -50,6 +52,7 @@ hooks:
 ```
 
 Rules:
+
 - Values are Go template expressions using the configured delimiters (default `{{ }}`) and the full Sprout FuncMap.
 - A computed key **must not** duplicate a user input key — error at load time.
 - A computed key **cannot** be overridden by `--values` or `--arg`.
@@ -137,7 +140,7 @@ computed:
 
 Computed values are available in template files and hook commands exactly like user inputs:
 
-```
+```text
 # Template file content
 DB_DATABASE={{ .DbName }}
 DB_TEST_DATABASE={{ .DbTestName }}

--- a/docs/content/docs/architecture/computed-values.md
+++ b/docs/content/docs/architecture/computed-values.md
@@ -59,13 +59,13 @@ Rules:
 
 ## Difference from Referenced Defaults
 
-| | Referenced default | Computed value |
-|---|---|---|
-| Defined as | String with `{{` in the user input section | Key under `computed:` |
-| User prompted? | Yes — shown with computed result as pre-fill | **No** |
-| User can override? | Yes | **No** |
-| Resolved when? | Before prompting (pre-fill calculation) | After all inputs are finalised |
-| Can reference other computed values? | No | Yes (topological sort) |
+|                                      | Referenced default                           | Computed value                 |
+|--------------------------------------|----------------------------------------------|--------------------------------|
+| Defined as                           | String with `{{` in the user input section   | Key under `computed:`          |
+| User prompted?                       | Yes — shown with computed result as pre-fill | **No**                         |
+| User can override?                   | Yes                                          | **No**                         |
+| Resolved when?                       | Before prompting (pre-fill calculation)      | After all inputs are finalised |
+| Can reference other computed values? | No                                           | Yes (topological sort)         |
 
 ---
 
@@ -123,13 +123,13 @@ computed:
 
 ## Error Handling
 
-| Situation | Behaviour |
-|---|---|
-| Computed key duplicates a user input key | Error at load time |
-| `--values` or `--arg` targets a computed key | Error before prompting |
-| Template syntax error in a computed value | Fatal error — names the key |
-| Reference to non-existent key | Fatal error — names the computed key |
-| Cycle between computed values | Fatal error — lists the keys involved |
+| Situation                                    | Behaviour                             |
+|----------------------------------------------|---------------------------------------|
+| Computed key duplicates a user input key     | Error at load time                    |
+| `--values` or `--arg` targets a computed key | Error before prompting                |
+| Template syntax error in a computed value    | Fatal error — names the key           |
+| Reference to non-existent key                | Fatal error — names the computed key  |
+| Cycle between computed values                | Fatal error — lists the keys involved |
 
 ---
 

--- a/docs/content/docs/architecture/library-decisions.md
+++ b/docs/content/docs/architecture/library-decisions.md
@@ -23,11 +23,11 @@ weight: 4
 - Usable in standalone mode (`form.Run()` blocks like a normal function call).
 - Covers every original prompt type, plus more:
 
-  | huh field | Replaces |
-  |-----------|---------|
-  | `Input` | `strPrompt` |
-  | `Confirm` | `boolPrompt` (yes/no) |
-  | `Select` | `multipleChoicePrompt` |
+  | huh field     | Replaces                |
+  |---------------|-------------------------|
+  | `Input`       | `strPrompt`             |
+  | `Confirm`     | `boolPrompt` (yes/no)   |
+  | `Select`      | `multipleChoicePrompt`  |
   | `MultiSelect` | *(not supported in v1)* |
 
 - Built-in theming (Charm, Dracula, Catppuccin, Base16, Default).
@@ -60,10 +60,10 @@ lipgloss styles. No bubbles table component is used.
 
 Future candidates if a full TUI is ever adopted:
 
-| Component | Potential use case |
-|-----------|---------|
-| `spinner` | Activity indicator during git clone / template execution |
-| `progress` | File copy progress for large templates |
+| Component  | Potential use case                                       |
+|------------|----------------------------------------------------------|
+| `spinner`  | Activity indicator during git clone / template execution |
+| `progress` | File copy progress for large templates                   |
 
 Full Bubbletea event loop adoption is deferred — huh already covers the interactive prompt UX.
 
@@ -150,18 +150,18 @@ configDir := filepath.Join(xdg.ConfigHome, "specs")
 
 ## Full Dependency Picture
 
-| Package | Purpose |
-|---------|---------|
-| `github.com/spf13/cobra` | CLI command tree |
-| `charm.land/huh/v2` | Interactive forms & prompts |
-| `charm.land/lipgloss/v2` | Output styling (logger + table renderer) |
-| `gopkg.in/yaml.v3` | `project.yml` parsing and `--values` YAML files |
-| `github.com/go-sprout/sprout` | Extended template functions |
-| `github.com/go-git/go-git/v5` | Git clone for template download/upgrade |
-| `github.com/adrg/xdg` | Config/data directory resolution |
-| `github.com/danwakefield/fnmatch` | Glob matching for `.specsverbatim` |
-| `github.com/Masterminds/semver/v3` | Semver comparison for `template upgrade` |
-| `github.com/sethvargo/go-password` | `password()` template function |
-| `github.com/docker/go-units` | `formatFilesize()` template function |
-| `golang.org/x/crypto` | SSH host key verification via `~/.ssh/known_hosts` |
-| `log/slog` | Internal debug logging (stdlib) |
+| Package                            | Purpose                                            |
+|------------------------------------|----------------------------------------------------|
+| `github.com/spf13/cobra`           | CLI command tree                                   |
+| `charm.land/huh/v2`                | Interactive forms & prompts                        |
+| `charm.land/lipgloss/v2`           | Output styling (logger + table renderer)           |
+| `gopkg.in/yaml.v3`                 | `project.yml` parsing and `--values` YAML files    |
+| `github.com/go-sprout/sprout`      | Extended template functions                        |
+| `github.com/go-git/go-git/v5`      | Git clone for template download/upgrade            |
+| `github.com/adrg/xdg`              | Config/data directory resolution                   |
+| `github.com/danwakefield/fnmatch`  | Glob matching for `.specsverbatim`                 |
+| `github.com/Masterminds/semver/v3` | Semver comparison for `template upgrade`           |
+| `github.com/sethvargo/go-password` | `password()` template function                     |
+| `github.com/docker/go-units`       | `formatFilesize()` template function               |
+| `golang.org/x/crypto`              | SSH host key verification via `~/.ssh/known_hosts` |
+| `log/slog`                         | Internal debug logging (stdlib)                    |

--- a/docs/content/docs/architecture/library-decisions.md
+++ b/docs/content/docs/architecture/library-decisions.md
@@ -8,6 +8,7 @@ weight: 4
 **Decision:** Keep `github.com/spf13/cobra`.
 
 **Rationale:**
+
 - The command tree (`specs template download|save|use|list|…`) is nested and will grow.
 - Cobra handles arbitrary subcommand depth cleanly via `AddCommand()`; flags can appear before or after arguments.
 - Best-in-class shell completion for bash, zsh, fish, and PowerShell.
@@ -20,6 +21,7 @@ weight: 4
 **Decision:** `charm.land/huh/v2` — full replacement for the old `internal/prompt`.
 
 **Rationale:**
+
 - Usable in standalone mode (`form.Run()` blocks like a normal function call).
 - Covers every original prompt type, plus more:
 
@@ -40,11 +42,13 @@ weight: 4
 **Decision:** `charm.land/lipgloss/v2` — replaces `fatih/color` and `tablewriter`.
 
 **Rationale:**
+
 - CSS-like chainable API for colour, bold/italic/underline, padding, margins, borders, and alignment.
 - Handles colour downsampling automatically (24-bit → 8-bit → 4-bit based on terminal capability).
 - `internal/util/output` provides the logger and table renderer on top of lipgloss.
 
 **Libraries replaced:**
+
 - `github.com/fatih/color`
 - `github.com/olekukonko/tablewriter`
 
@@ -75,6 +79,7 @@ Full Bubbletea event loop adoption is deferred — huh already covers the intera
 Backwards compatibility layer is **not** used.
 
 **Rationale:**
+
 - Sprig is effectively unmaintained; sprout is its active successor.
 - Functions are grouped into opt-in registries — only pull in what is needed.
 - `env` and `expandenv` are not included by default — templates cannot read host environment
@@ -88,6 +93,7 @@ Backwards compatibility layer is **not** used.
 **Decision:** `log/slog` (standard library, Go ≥ 1.21).
 
 **Rationale:**
+
 - Zero additional dependency.
 - Structured key-value fields give context to debug messages.
 - Silent by default; activated by `--debug` on the root command.
@@ -99,6 +105,7 @@ Backwards compatibility layer is **not** used.
 **Decision:** `gopkg.in/yaml.v3` — replaces `encoding/json` for reading `project.yml`.
 
 **Rationale:**
+
 - YAML supports comments, making template config files self-documenting.
 - `gopkg.in/yaml.v3` unmarshals into `map[string]any` identically to `encoding/json`.
 - Also used for `--values` files: `.yaml`/`.yml` extensions are parsed as YAML,
@@ -128,6 +135,7 @@ configDir := filepath.Join(xdg.ConfigHome, "specs")
 **Decision:** `github.com/Masterminds/semver/v3` for semver-aware version comparison.
 
 **Rationale:**
+
 - `specs template update`/`upgrade` compare local and remote tag versions to find the highest
   available semver tag greater than the currently installed version. This applies both to
   tag-tracked templates and to branch-tracked templates whose checkout sits on a semver tag, so
@@ -141,6 +149,7 @@ configDir := filepath.Join(xdg.ConfigHome, "specs")
 **Decision:** `golang.org/x/crypto` for SSH host key verification via `knownhosts.New`.
 
 **Rationale:**
+
 - go-git requires an explicit `HostKeyCallback` for SSH connections.
 - `golang.org/x/crypto/ssh/knownhosts` reads `~/.ssh/known_hosts` and builds a callback
   that prevents MITM attacks.

--- a/docs/content/docs/architecture/overview.md
+++ b/docs/content/docs/architecture/overview.md
@@ -19,7 +19,7 @@ weight: 1
 
 ## Package Structure
 
-```
+```text
 specs-cli/
 ├── main.go                       # main() — XDG init, cmd.Execute()
 ├── go.mod
@@ -72,7 +72,7 @@ specs-cli/
 
 ## CLI Command Tree
 
-```
+```text
 specs [--version|-v]
       [--debug]                             enable debug output
       [--safe-mode]                         disable env/filesystem template functions + hooks
@@ -134,7 +134,7 @@ SSH clones are authenticated automatically via SSH agent or standard key files
 
 ## Template Structure
 
-```
+```text
 <template-root>/
 ├── project.yml              # variable schema, defaults, optional inline hooks
 ├── .specsverbatim            # verbatim-copy glob patterns (opt-out from rendering)
@@ -156,7 +156,7 @@ SSH clones are authenticated automatically via SSH agent or standard key files
 
 ## Configuration
 
-```
+```text
 $XDG_CONFIG_HOME/specs/          (default: ~/.config/specs/)
 └── templates/
     └── <name>/

--- a/docs/content/docs/architecture/overview.md
+++ b/docs/content/docs/architecture/overview.md
@@ -108,15 +108,15 @@ specs [--version|-v]
 
 One-step command — downloads, executes, discards. No registry entry created.
 
-| Format | Example |
-|--------|---------|
-| GitHub shorthand | `github:Ilyes512/boilr-laravel-project` |
-| GitHub with branch | `github:Ilyes512/boilr-laravel-project:main` |
-| Full HTTPS URL | `https://github.com/Ilyes512/boilr-laravel-project` |
-| SCP-style SSH | `git@github.com:Ilyes512/boilr-laravel-project` |
-| SSH URL | `ssh://git@github.com/Ilyes512/boilr-laravel-project` |
-| Local path (explicit) | `file:./my-template` |
-| Local path (implicit) | `./my-template` or `/absolute/path` |
+| Format                | Example                                               |
+|-----------------------|-------------------------------------------------------|
+| GitHub shorthand      | `github:Ilyes512/boilr-laravel-project`               |
+| GitHub with branch    | `github:Ilyes512/boilr-laravel-project:main`          |
+| Full HTTPS URL        | `https://github.com/Ilyes512/boilr-laravel-project`   |
+| SCP-style SSH         | `git@github.com:Ilyes512/boilr-laravel-project`       |
+| SSH URL               | `ssh://git@github.com/Ilyes512/boilr-laravel-project` |
+| Local path (explicit) | `file:./my-template`                                  |
+| Local path (implicit) | `./my-template` or `/absolute/path`                   |
 
 **Source validation rules** (enforced at parse time, before any network call):
 
@@ -249,21 +249,21 @@ flowchart TD
 Sentinel errors are declared in `internal/specs/errors.go` and should always be wrapped with `%w`
 so that callers can use `errors.Is` to distinguish them:
 
-| Sentinel | Kind string | Raised when |
-|----------|-------------|-------------|
-| `ErrTemplateNotFound` | `template_not_found` | Named template does not exist in the registry |
-| `ErrTemplateAlreadyExists` | `template_already_exists` | Template name is already in use (save/download/rename without `--force`) |
-| `ErrTemplateDirMissing` | `template_dir_missing` | Template root exists but has no `template/` subdirectory |
-| `ErrBothHookSources` | `both_hook_sources` | Both inline hooks and a `hooks/` directory are present |
-| `ErrAmbiguousProjectFile` | `ambiguous_project_file` | Both `project.yaml` and `project.yml` exist in the template root |
-| `ErrInvalidDelimiters` | `invalid_delimiters` | `__delimiters` in `project.yaml` is malformed |
-| `ErrProjectFileMissing` | `project_file_missing` | No `project.yaml`, `project.yml`, or `project.json` found |
-| `ErrLocalSource` | `local_source` | Local path given to a command that requires a remote URL |
-| `ErrInvalidComputedDef` | `invalid_computed_def` | `computed:` entry in `project.yaml` has wrong type, value type mismatch, or key conflict |
-| `ErrCyclicDependency` | `cyclic_dependency` | Cycle detected among computed or referenced-default keys |
-| `ErrInvalidSpecsVersion` | `invalid_specs_version` | `__specs__version` in `project.yaml` is not a string or not a parseable semver constraint |
-| `ErrSpecsVersionUnsatisfied` | `specs_version_unsatisfied` | Running CLI version does not satisfy the template's `__specs__version` constraint |
-| `ErrReservedVariableName` | `reserved_variable_name` | A variable or computed name uses the reserved `__` prefix without being a recognised configuration key |
+| Sentinel                     | Kind string                 | Raised when                                                                                            |
+|------------------------------|-----------------------------|--------------------------------------------------------------------------------------------------------|
+| `ErrTemplateNotFound`        | `template_not_found`        | Named template does not exist in the registry                                                          |
+| `ErrTemplateAlreadyExists`   | `template_already_exists`   | Template name is already in use (save/download/rename without `--force`)                               |
+| `ErrTemplateDirMissing`      | `template_dir_missing`      | Template root exists but has no `template/` subdirectory                                               |
+| `ErrBothHookSources`         | `both_hook_sources`         | Both inline hooks and a `hooks/` directory are present                                                 |
+| `ErrAmbiguousProjectFile`    | `ambiguous_project_file`    | Both `project.yaml` and `project.yml` exist in the template root                                       |
+| `ErrInvalidDelimiters`       | `invalid_delimiters`        | `__delimiters` in `project.yaml` is malformed                                                          |
+| `ErrProjectFileMissing`      | `project_file_missing`      | No `project.yaml`, `project.yml`, or `project.json` found                                              |
+| `ErrLocalSource`             | `local_source`              | Local path given to a command that requires a remote URL                                               |
+| `ErrInvalidComputedDef`      | `invalid_computed_def`      | `computed:` entry in `project.yaml` has wrong type, value type mismatch, or key conflict               |
+| `ErrCyclicDependency`        | `cyclic_dependency`         | Cycle detected among computed or referenced-default keys                                               |
+| `ErrInvalidSpecsVersion`     | `invalid_specs_version`     | `__specs__version` in `project.yaml` is not a string or not a parseable semver constraint              |
+| `ErrSpecsVersionUnsatisfied` | `specs_version_unsatisfied` | Running CLI version does not satisfy the template's `__specs__version` constraint                      |
+| `ErrReservedVariableName`    | `reserved_variable_name`    | A variable or computed name uses the reserved `__` prefix without being a recognised configuration key |
 
 `specs.KindOf(err error) string` returns the stable kind string for any error in the chain,
 or `""` when no known sentinel is wrapped.
@@ -287,10 +287,10 @@ type Writer interface {
 
 Two implementations are selected at startup via `--output`:
 
-| Flag value | Writer | Behaviour |
-|---|---|---|
-| `pretty` (default) | `HumanWriter` | Lipgloss-styled text; `Info` → stdout, `Warn`/`Error`/`WriteErr` → stderr |
-| `json` | `JSONWriter` | NDJSON lines; `Table` → JSON array to stdout; `WriteErr` adds `"error_kind"` for known sentinels |
+| Flag value         | Writer        | Behaviour                                                                                        |
+|--------------------|---------------|--------------------------------------------------------------------------------------------------|
+| `pretty` (default) | `HumanWriter` | Lipgloss-styled text; `Info` → stdout, `Warn`/`Error`/`WriteErr` → stderr                        |
+| `json`             | `JSONWriter`  | NDJSON lines; `Table` → JSON array to stdout; `WriteErr` adds `"error_kind"` for known sentinels |
 
 `JSONWriter.WriteErr` example for a known sentinel:
 
@@ -317,42 +317,42 @@ log point is `Debug`, suppressed at the default `Info` level) and is distinct fr
 
 ### Flags
 
-| Flag | Effect |
-|------|--------|
-| `--debug` | Raises the slog level from `Info` to `Debug`; all debug logs become visible |
+| Flag                        | Effect                                                                                                                        |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `--debug`                   | Raises the slog level from `Info` to `Debug`; all debug logs become visible                                                   |
 | `--output=json` + `--debug` | Swaps the slog handler to `slog.NewJSONHandler` writing to stderr; debug logs are emitted as NDJSON distinct from stdout data |
 
 ### Log points
 
-| Package | Function | Level | Attributes |
-|---------|----------|-------|------------|
-| `internal/template` | `Get` | Debug | `template`, `keys`, `computed` |
-| `internal/template` | `Execute` | Debug | `path`, `dest`, `action` (render/verbatim/skip) |
-| `internal/template` | `Execute` | Debug | `template`, `dest`, `rendered`, `verbatim`, `skipped` (summary) |
-| `internal/template` | `ApplyComputed` | Debug | `key`, `source`="computed" |
-| `internal/hooks` | `Hooks.Run` | Debug | `trigger`, `commands`, `command` |
-| `internal/cmd` | `executeTemplate` | Debug | `key`, `source` (values_file/arg_flag/default/prompt) — one log per key, final source only |
-| `internal/registry` | `Upgrade` | Debug | `template`, `repo`, `branch`, `target_ref`, `latest_version` |
-| `internal/util/git` | `Clone` | Debug | `repo`, `dest`, `branch` (start and complete) |
-| `internal/util/git` | `Describe` | Debug | `dest`, `commit`, `version` (or `error` on failure) |
-| `internal/util/git` | `CheckRemoteContext` | Debug | `repo`, `branch`, `dest`, `up_to_date`, `latest_version`, `error_kind` |
+| Package             | Function             | Level | Attributes                                                                                 |
+|---------------------|----------------------|-------|--------------------------------------------------------------------------------------------|
+| `internal/template` | `Get`                | Debug | `template`, `keys`, `computed`                                                             |
+| `internal/template` | `Execute`            | Debug | `path`, `dest`, `action` (render/verbatim/skip)                                            |
+| `internal/template` | `Execute`            | Debug | `template`, `dest`, `rendered`, `verbatim`, `skipped` (summary)                            |
+| `internal/template` | `ApplyComputed`      | Debug | `key`, `source`="computed"                                                                 |
+| `internal/hooks`    | `Hooks.Run`          | Debug | `trigger`, `commands`, `command`                                                           |
+| `internal/cmd`      | `executeTemplate`    | Debug | `key`, `source` (values_file/arg_flag/default/prompt) — one log per key, final source only |
+| `internal/registry` | `Upgrade`            | Debug | `template`, `repo`, `branch`, `target_ref`, `latest_version`                               |
+| `internal/util/git` | `Clone`              | Debug | `repo`, `dest`, `branch` (start and complete)                                              |
+| `internal/util/git` | `Describe`           | Debug | `dest`, `commit`, `version` (or `error` on failure)                                        |
+| `internal/util/git` | `CheckRemoteContext` | Debug | `repo`, `branch`, `dest`, `up_to_date`, `latest_version`, `error_kind`                     |
 
 ### Consistent attribute keys
 
-| Key | Meaning |
-|-----|---------|
-| `template` | Registered template name (e.g. `"minimal"`) — primary user identifier |
-| `path` | Template-relative source path of a file (e.g. `"src/foo.go"`) |
-| `dest` | Absolute destination path on the filesystem |
-| `repo` | Remote repository URL |
-| `branch` | Git branch or tag ref |
-| `commit` | Full git commit SHA |
-| `version` | git-describe-style version string |
-| `trigger` | Hook trigger name (`pre-use`, `post-use`) |
-| `key` | Context variable name |
-| `source` | How a context value was provided (`default`/`prompt`/`values_file`/`arg_flag`/`computed`) |
-| `action` | File decision (`render`/`verbatim`/`skip`) |
-| `error` | Underlying error (formatted as `%v`) |
+| Key        | Meaning                                                                                   |
+|------------|-------------------------------------------------------------------------------------------|
+| `template` | Registered template name (e.g. `"minimal"`) — primary user identifier                     |
+| `path`     | Template-relative source path of a file (e.g. `"src/foo.go"`)                             |
+| `dest`     | Absolute destination path on the filesystem                                               |
+| `repo`     | Remote repository URL                                                                     |
+| `branch`   | Git branch or tag ref                                                                     |
+| `commit`   | Full git commit SHA                                                                       |
+| `version`  | git-describe-style version string                                                         |
+| `trigger`  | Hook trigger name (`pre-use`, `post-use`)                                                 |
+| `key`      | Context variable name                                                                     |
+| `source`   | How a context value was provided (`default`/`prompt`/`values_file`/`arg_flag`/`computed`) |
+| `action`   | File decision (`render`/`verbatim`/`skip`)                                                |
+| `error`    | Underlying error (formatted as `%v`)                                                      |
 
 ### Example: structured debug output
 
@@ -398,21 +398,21 @@ func (h *Hooks) Run(trigger, cwd string, ctx map[string]any, funcMap template.Fu
 
 ## Packages Added / Changed vs boilr v1
 
-| Package | Status | Change |
-|---------|--------|--------|
-| `internal/specs` | **new** | XDG paths, file name constants, sentinel errors, `KindOf()` (replaces `pkg/boilr`) |
-| `internal/registry` | **new** | on-disk template store: `Entry`, `Load()`, `Upgrade()` |
-| `internal/cmd` | updated | new `use.go`, `template_update.go`, `template_upgrade.go`, iterative conditional prompting; no longer reads project files or `__metadata.json` directly |
-| `internal/template` | updated | configurable delimiters (default `{{ }}`), `context.go`, `verbatim.go`, conditional skip, AST analysis, status; exports `LoadProjectFile()`, `LoadMetadata()`, `SaveMetadata()` |
-| `internal/hooks` | **new** | hook loading and execution |
-| `internal/util/output` | updated | lipgloss-based logger + table renderer; `WriteErr` with JSON `error_kind` for known sentinels (replaces tlog + tabular) |
-| `internal/util/values` | **new** | `--values` file (JSON/YAML) and `--arg` flag parsing |
-| `internal/host` | updated | source format parsing (github:, HTTPS, SSH, local path) |
-| `pkg/prompt` | **removed** | replaced by `huh` |
-| `pkg/util/tlog` | **removed** | replaced by `internal/util/output` |
-| `pkg/util/tabular` | **removed** | replaced by `internal/util/output` |
-| `pkg/util/exec` | **removed** | no longer needed (hooks use `os/exec` directly) |
-| `internal/util/exit` | unchanged | |
-| `internal/util/git` | updated | SSH auth, `CheckRemoteContext()` (context-aware), `Describe()` for status tracking; `RemoteCheckResult.Err()` returns typed sentinel errors |
-| `internal/util/osutil` | updated | `CopyDir()` recursive copy |
-| `internal/util/validate` | updated | `Name()` validator (alphanumeric + hyphens + underscores) |
+| Package                  | Status      | Change                                                                                                                                                                          |
+|--------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `internal/specs`         | **new**     | XDG paths, file name constants, sentinel errors, `KindOf()` (replaces `pkg/boilr`)                                                                                              |
+| `internal/registry`      | **new**     | on-disk template store: `Entry`, `Load()`, `Upgrade()`                                                                                                                          |
+| `internal/cmd`           | updated     | new `use.go`, `template_update.go`, `template_upgrade.go`, iterative conditional prompting; no longer reads project files or `__metadata.json` directly                         |
+| `internal/template`      | updated     | configurable delimiters (default `{{ }}`), `context.go`, `verbatim.go`, conditional skip, AST analysis, status; exports `LoadProjectFile()`, `LoadMetadata()`, `SaveMetadata()` |
+| `internal/hooks`         | **new**     | hook loading and execution                                                                                                                                                      |
+| `internal/util/output`   | updated     | lipgloss-based logger + table renderer; `WriteErr` with JSON `error_kind` for known sentinels (replaces tlog + tabular)                                                         |
+| `internal/util/values`   | **new**     | `--values` file (JSON/YAML) and `--arg` flag parsing                                                                                                                            |
+| `internal/host`          | updated     | source format parsing (github:, HTTPS, SSH, local path)                                                                                                                         |
+| `pkg/prompt`             | **removed** | replaced by `huh`                                                                                                                                                               |
+| `pkg/util/tlog`          | **removed** | replaced by `internal/util/output`                                                                                                                                              |
+| `pkg/util/tabular`       | **removed** | replaced by `internal/util/output`                                                                                                                                              |
+| `pkg/util/exec`          | **removed** | no longer needed (hooks use `os/exec` directly)                                                                                                                                 |
+| `internal/util/exit`     | unchanged   |                                                                                                                                                                                 |
+| `internal/util/git`      | updated     | SSH auth, `CheckRemoteContext()` (context-aware), `Describe()` for status tracking; `RemoteCheckResult.Err()` returns typed sentinel errors                                     |
+| `internal/util/osutil`   | updated     | `CopyDir()` recursive copy                                                                                                                                                      |
+| `internal/util/validate` | updated     | `Name()` validator (alphanumeric + hyphens + underscores)                                                                                                                       |

--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -50,13 +50,13 @@ computed:
   Year:   "{{ now | date \"2006\" }}"
 ```
 
-| Value type | Prompt behaviour |
-|------------|-----------------|
-| `string`   | Free-text input with default shown |
-| `bool`     | Yes/No confirm prompt |
-| `[]string` | Select list; first item is default |
-| `string` containing `{{` | Referenced default — pre-fill computed, user can override |
-| `computed:` section | Never prompted — derived after all user inputs are finalised |
+| Value type               | Prompt behaviour                                             |
+|--------------------------|--------------------------------------------------------------|
+| `string`                 | Free-text input with default shown                           |
+| `bool`                   | Yes/No confirm prompt                                        |
+| `[]string`               | Select list; first item is default                           |
+| `string` containing `{{` | Referenced default — pre-fill computed, user can override    |
+| `computed:` section      | Never prompted — derived after all user inputs are finalised |
 
 ---
 
@@ -130,13 +130,13 @@ be expressed. `template.ExtractSpecsVersion` parses it with `semver.NewConstrain
 `checkSpecsVersion` helper then evaluates it against the running CLI version (injected via
 `Config.Version` from the cmd layer, so `pkg/template` never imports `pkg/cmd`):
 
-| Condition | Outcome |
-|-----------|---------|
-| Key absent | No check — proceed |
-| Present but not a string, or not a parseable constraint | `ErrInvalidSpecsVersion` — refuse to load |
+| Condition                                                  | Outcome                                                               |
+|------------------------------------------------------------|-----------------------------------------------------------------------|
+| Key absent                                                 | No check — proceed                                                    |
+| Present but not a string, or not a parseable constraint    | `ErrInvalidSpecsVersion` — refuse to load                             |
 | `Config.Version` is empty, `dev`, or otherwise unparseable | Check skipped with a `slog.Debug` line — never lock out source builds |
-| Parsed CLI version does not satisfy the constraint | `ErrSpecsVersionUnsatisfied` (wrapped with `%w`) |
-| Parsed CLI version satisfies the constraint | Proceed |
+| Parsed CLI version does not satisfy the constraint         | `ErrSpecsVersionUnsatisfied` (wrapped with `%w`)                      |
+| Parsed CLI version satisfies the constraint                | Proceed                                                               |
 
 The gate fires for both `specs use` and `specs template use` (which share `executeTemplate`).
 `specs template save` never calls `Get()`, so a newer template can still be saved on an older
@@ -149,9 +149,9 @@ CLI. The reserved key is consumed during load and never exposed as a template va
 The following files are silently skipped during rendering, regardless of any other
 configuration. They are OS/editor metadata that should never appear in scaffolded output:
 
-| Filename | Origin |
-|----------|--------|
-| `.DS_Store` | macOS Finder |
+| Filename    | Origin           |
+|-------------|------------------|
+| `.DS_Store` | macOS Finder     |
 | `Thumbs.db` | Windows Explorer |
 
 These files are skipped at the walk stage — they are never copied, rendered, or passed to
@@ -189,11 +189,11 @@ template/
     └── badge.png
 ```
 
-| `UseSonarQube` | Rendered path | Result |
-|---|---|---|
-| `true` | `sonar-project.properties` | created |
-| `false` | *(empty)* | skipped |
-| `false` (badge.png) | `/badge.png` | skipped — empty segment |
+| `UseSonarQube`      | Rendered path              | Result                  |
+|---------------------|----------------------------|-------------------------|
+| `true`              | `sonar-project.properties` | created                 |
+| `false`             | *(empty)*                  | skipped                 |
+| `false` (badge.png) | `/badge.png`               | skipped — empty segment |
 
 ---
 
@@ -227,10 +227,10 @@ flowchart TD
 
 ### Render error modes
 
-| Mode | Behaviour | How to enable |
-|------|-----------|---------------|
-| **Fail-fast** (default) | Parse or execution errors abort `Execute` immediately; no destination file is written for the affected path. The tmp dir is cleaned up by the deferred `os.RemoveAll` in `template use`. | Default — no flag needed |
-| **Continue-on-error** | Parse or execution errors are recorded as `RenderWarning` entries and the file is copied verbatim. Restores the pre-v0.x behaviour. Use only when `.specsverbatim` is not an option. | `--continue-on-error` flag |
+| Mode                    | Behaviour                                                                                                                                                                                | How to enable              |
+|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
+| **Fail-fast** (default) | Parse or execution errors abort `Execute` immediately; no destination file is written for the affected path. The tmp dir is cleaned up by the deferred `os.RemoveAll` in `template use`. | Default — no flag needed   |
+| **Continue-on-error**   | Parse or execution errors are recorded as `RenderWarning` entries and the file is copied verbatim. Restores the pre-v0.x behaviour. Use only when `.specsverbatim` is not an option.     | `--continue-on-error` flag |
 
 If any `RenderWarning` entries are present after `Execute` returns (only possible with `--continue-on-error`):
 
@@ -297,13 +297,13 @@ All of Go's standard `text/template` built-ins are available, plus:
 
 ### Custom Functions (`internal/template/specsregistry.go`)
 
-| Function | Signature | Description |
-|----------|-----------|-------------|
-| `hostname` | `() string` | System hostname |
-| `username` | `() string` | Current OS username |
-| `toBinary` | `(n int) string` | Format integer as binary string |
-| `formatFilesize` | `(bytes float64) string` | Human-readable size (KB/MB/GB…) |
-| `password` | `(length, digits, symbols int, noUpper, allowRepeat bool) string` | Secure random password |
+| Function         | Signature                                                         | Description                     |
+|------------------|-------------------------------------------------------------------|---------------------------------|
+| `hostname`       | `() string`                                                       | System hostname                 |
+| `username`       | `() string`                                                       | Current OS username             |
+| `toBinary`       | `(n int) string`                                                  | Format integer as binary string |
+| `formatFilesize` | `(bytes float64) string`                                          | Human-readable size (KB/MB/GB…) |
+| `password`       | `(length, digits, symbols int, noUpper, allowRepeat bool) string` | Secure random password          |
 
 ### Sprout Functions
 
@@ -312,14 +312,14 @@ All functions from [`go-sprout/sprout`](https://github.com/go-sprout/sprout) are
 
 Key renamed functions vs the old sprig library:
 
-| Old (sprig) | New (sprout) |
-|---|---|
-| `kebabcase` | `toKebabCase` |
-| `snakecase` | `toSnakeCase` |
-| `camelcase` | `toPascalCase` |
-| `upper` | `toUpper` |
-| `lower` | `toLower` |
-| `title` | `toTitleCase` |
+| Old (sprig)         | New (sprout)                    |
+|---------------------|---------------------------------|
+| `kebabcase`         | `toKebabCase`                   |
+| `snakecase`         | `toSnakeCase`                   |
+| `camelcase`         | `toPascalCase`                  |
+| `upper`             | `toUpper`                       |
+| `lower`             | `toLower`                       |
+| `title`             | `toTitleCase`                   |
 | `b64enc` / `b64dec` | `base64Encode` / `base64Decode` |
 
 ### Template Options
@@ -354,14 +354,14 @@ entirely — they are never prompted regardless of their presence in `project.ym
 
 The condition types recognised by the AST analyser are:
 
-| Template expression | Condition type |
-|---|---|
-| `{{ if .Var }}` | `condField` — truthy check |
-| `{{ if not .Var }}` | `condNot` — negation |
-| `{{ if eq .Var "value" }}` | `condEq` — equality |
-| `{{ if ne .Var "value" }}` | `condNe` — inequality |
-| `{{ if and .A .B }}` | `condAnd` — conjunction |
-| `{{ if or .A .B }}` | `condOr` — disjunction |
+| Template expression        | Condition type             |
+|----------------------------|----------------------------|
+| `{{ if .Var }}`            | `condField` — truthy check |
+| `{{ if not .Var }}`        | `condNot` — negation       |
+| `{{ if eq .Var "value" }}` | `condEq` — equality        |
+| `{{ if ne .Var "value" }}` | `condNe` — inequality      |
+| `{{ if and .A .B }}`       | `condAnd` — conjunction    |
+| `{{ if or .A .B }}`        | `condOr` — disjunction     |
 
 Unrecognised condition forms fall back to treating the variable as always-needed
 (conservative: over-prompt rather than under-prompt).
@@ -372,9 +372,9 @@ Unrecognised condition forms fall back to treating the variable as always-needed
 
 Hooks run shell commands before and after `specs template use`. Two trigger points:
 
-| Hook | Working directory | Runs |
-|------|------------------|-------|
-| `pre-use` | template source directory | Before any files are rendered. Non-zero exit aborts. |
+| Hook       | Working directory         | Runs                                                                                  |
+|------------|---------------------------|---------------------------------------------------------------------------------------|
+| `pre-use`  | template source directory | Before any files are rendered. Non-zero exit aborts.                                  |
 | `post-use` | target (output) directory | After all files are written. Receives resolved context as `SPECS_`-prefixed env vars. |
 
 Two mutually exclusive definition forms:
@@ -411,14 +411,14 @@ The prefix can be disabled with the root `--no-env-prefix` flag.
 
 Hooks run arbitrary shell commands on the host. Before running any template with hooks:
 
-| Scenario | Behaviour |
-|---|---|
-| `--safe-mode` (no `--allow-hooks`) | Hooks are **skipped entirely** — no bash invocation |
-| `--safe-mode --allow-hooks` | Function-level restrictions apply; hooks **run** (remote confirmation still required) |
-| `specs use <remote>` with hooks | Rendered hook commands are **printed** and **interactive confirmation** is required |
-| `specs use <remote> --yes` | Confirmation prompt is skipped; hooks run (CI use) |
-| `specs use <remote> --no-hooks` | Hooks are **skipped** |
-| Local template or registry template | No confirmation prompt; hooks run as normal |
+| Scenario                            | Behaviour                                                                             |
+|-------------------------------------|---------------------------------------------------------------------------------------|
+| `--safe-mode` (no `--allow-hooks`)  | Hooks are **skipped entirely** — no bash invocation                                   |
+| `--safe-mode --allow-hooks`         | Function-level restrictions apply; hooks **run** (remote confirmation still required) |
+| `specs use <remote>` with hooks     | Rendered hook commands are **printed** and **interactive confirmation** is required   |
+| `specs use <remote> --yes`          | Confirmation prompt is skipped; hooks run (CI use)                                    |
+| `specs use <remote> --no-hooks`     | Hooks are **skipped**                                                                 |
+| Local template or registry template | No confirmation prompt; hooks run as normal                                           |
 
 **`--safe-mode` implies `--no-hooks`** in the command layer. Pass `--allow-hooks` alongside `--safe-mode` to disable only the env/filesystem template functions while still allowing hooks to execute.
 
@@ -470,20 +470,20 @@ It calls `Execute` on a temporary directory first to catch render errors, then c
 
 Three categories of issues are reported:
 
-| Issue kind | Source | Meaning |
-|---|---|---|
-| `render_error` | `Execute()` | A file could not be rendered (parse or execution error) and was copied verbatim. |
-| `unknown_variable` | `Validate()` | A name used in a template file or path is **not defined** in `project.yaml`. |
-| `unused_variable` | `Validate()` | A variable **defined** in the user input section is never referenced anywhere. |
-| `unused_computed` | `Validate()` | A computed value **defined** under `computed:` is never referenced anywhere. |
+| Issue kind         | Source       | Meaning                                                                          |
+|--------------------|--------------|----------------------------------------------------------------------------------|
+| `render_error`     | `Execute()`  | A file could not be rendered (parse or execution error) and was copied verbatim. |
+| `unknown_variable` | `Validate()` | A name used in a template file or path is **not defined** in `project.yaml`.     |
+| `unused_variable`  | `Validate()` | A variable **defined** in the user input section is never referenced anywhere.   |
+| `unused_computed`  | `Validate()` | A computed value **defined** under `computed:` is never referenced anywhere.     |
 
 Exit codes are a bitmask — multiple conditions combine additively:
 
-| Bit | Constant | Value | Condition |
-|-----|----------|-------|-----------|
-| 2 | `ValidateRender` | 4 | Any `render_error` — file copied verbatim due to parse or execution error |
-| 1 | `ValidateUnknown` | 2 | Any `unknown_variable` |
-| 0 | `ValidateUnused` | 1 | Any `unused_*` (only with `--strict`) |
+| Bit | Constant          | Value | Condition                                                                 |
+|-----|-------------------|-------|---------------------------------------------------------------------------|
+| 2   | `ValidateRender`  | 4     | Any `render_error` — file copied verbatim due to parse or execution error |
+| 1   | `ValidateUnknown` | 2     | Any `unknown_variable`                                                    |
+| 0   | `ValidateUnused`  | 1     | Any `unused_*` (only with `--strict`)                                     |
 
 `specs template validate` exits 0 only when there are no render errors and no unknown variables.
 

--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -7,7 +7,7 @@ weight: 2
 
 Every specs template is a directory with this structure:
 
-```
+```text
 <template-root>/
 ├── project.yml          # variable schema with defaults
 ├── .specsverbatim        # verbatim-copy glob patterns (opt-out from rendering)
@@ -165,7 +165,7 @@ ever added in the future.
 A `.specsverbatim` file at the template root lists glob patterns for files that should be
 copied byte-for-byte without any template rendering:
 
-```
+```text
 # .specsverbatim
 composer.lock
 package-lock.json
@@ -182,7 +182,7 @@ Use the filename itself as a template expression. After rendering:
 - Empty or whitespace result → skip the file/directory
 - Any **path segment** empty → skip the file (enables conditional directory trees)
 
-```
+```text
 template/
 └── {{ if .UseSonarQube }}sonar-project.properties{{ end }}
 └── {{ if .UseSonarQube }}docs/images{{ end }}/
@@ -260,7 +260,7 @@ are copied byte-for-byte; no template rendering is attempted.
 Binary detection is best-effort. Any file that must be copied verbatim should be listed
 explicitly in `.specsverbatim` rather than relying on auto-detection:
 
-```
+```text
 # .specsverbatim — recommended patterns for common binary assets
 *.png
 *.jpg
@@ -380,6 +380,7 @@ Hooks run shell commands before and after `specs template use`. Two trigger poin
 Two mutually exclusive definition forms:
 
 **Form A — inline in `project.yml`:**
+
 ```yaml
 hooks:
   pre-use:
@@ -394,7 +395,8 @@ hooks:
 ```
 
 **Form B — script files:**
-```
+
+```text
 template-root/
 ├── project.yml
 ├── hooks/

--- a/docs/content/docs/commands/global-flags.md
+++ b/docs/content/docs/commands/global-flags.md
@@ -4,9 +4,9 @@ weight: 3
 next: /docs/template-structure
 ---
 
-| Flag | Description |
-|------|-------------|
+| Flag              | Description                                                                 |
+|-------------------|-----------------------------------------------------------------------------|
 | `--output` / `-o` | Output format: `pretty` (default, styled) or `json` (NDJSON, for scripting) |
-| `--debug` | Enable debug-level logging |
-| `--safe-mode` | Disable env/filesystem functions and skip hooks |
-| `--no-env-prefix` | Remove the `SPECS_` prefix from hook environment variables |
+| `--debug`         | Enable debug-level logging                                                  |
+| `--safe-mode`     | Disable env/filesystem functions and skip hooks                             |
+| `--no-env-prefix` | Remove the `SPECS_` prefix from hook environment variables                  |

--- a/docs/content/docs/commands/template.md
+++ b/docs/content/docs/commands/template.md
@@ -7,17 +7,17 @@ Manage a local registry of named templates. Unlike `specs use`, downloaded templ
 
 ## Subcommands
 
-| Subcommand | Description |
-|------------|-------------|
-| `list` / `ls` | List registered templates with update status. Stale statuses (older than 24 hours) are refreshed automatically. Use `--output json` for machine-readable NDJSON output. |
-| `save <path> <name>` | Register a local directory as a template |
-| `download` / `add <source> <name>` | Download a remote template and save it to the local registry |
-| `use <name> <target-dir>` | Execute a registered template |
-| `validate <path>` | Check if a template directory is valid |
-| `rename` / `mv <old> <new>` | Rename a registered template |
-| `delete` / `rm` / `remove` / `del <name>...` | Remove one or more templates from the registry |
-| `update [name]` | Force-refresh the cached update status; updates all template statuses if no name is given |
-| `upgrade [name]` | Apply available updates; upgrades all remote templates if no name is given |
+| Subcommand                                   | Description                                                                                                                                                             |
+|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `list` / `ls`                                | List registered templates with update status. Stale statuses (older than 24 hours) are refreshed automatically. Use `--output json` for machine-readable NDJSON output. |
+| `save <path> <name>`                         | Register a local directory as a template                                                                                                                                |
+| `download` / `add <source> <name>`           | Download a remote template and save it to the local registry                                                                                                            |
+| `use <name> <target-dir>`                    | Execute a registered template                                                                                                                                           |
+| `validate <path>`                            | Check if a template directory is valid                                                                                                                                  |
+| `rename` / `mv <old> <new>`                  | Rename a registered template                                                                                                                                            |
+| `delete` / `rm` / `remove` / `del <name>...` | Remove one or more templates from the registry                                                                                                                          |
+| `update [name]`                              | Force-refresh the cached update status; updates all template statuses if no name is given                                                                               |
+| `upgrade [name]`                             | Apply available updates; upgrades all remote templates if no name is given                                                                                              |
 
 `template use` accepts the same flags as `specs use` (`--values`, `--arg`, `--use-defaults`, `--no-hooks`).
 

--- a/docs/content/docs/commands/use.md
+++ b/docs/content/docs/commands/use.md
@@ -13,26 +13,26 @@ specs use github:specsnl/go-service ./new-service --arg projectName=my-service
 
 ## Source formats
 
-| Format | Example |
-|--------|---------|
-| GitHub shorthand (default branch) | `github:specsnl/go-service` |
-| GitHub shorthand with branch | `github:specsnl/go-service:main` |
-| GitHub shorthand with tag | `github:specsnl/go-service:v1.2.0` |
-| Full HTTPS URL | `https://github.com/specsnl/go-service` |
+| Format                            | Example                                     |
+|-----------------------------------|---------------------------------------------|
+| GitHub shorthand (default branch) | `github:specsnl/go-service`                 |
+| GitHub shorthand with branch      | `github:specsnl/go-service:main`            |
+| GitHub shorthand with tag         | `github:specsnl/go-service:v1.2.0`          |
+| Full HTTPS URL                    | `https://github.com/specsnl/go-service`     |
 | Full HTTPS URL with `.git` suffix | `https://github.com/specsnl/go-service.git` |
-| SCP-style SSH URL | `git@github.com:specsnl/go-service` |
-| Explicit SSH URL | `ssh://git@github.com/specsnl/go-service` |
-| Relative local path | `./local-template` |
-| Absolute local path | `/home/user/templates/go-service` |
-| Explicit local path prefix | `file:./local-template` |
+| SCP-style SSH URL                 | `git@github.com:specsnl/go-service`         |
+| Explicit SSH URL                  | `ssh://git@github.com/specsnl/go-service`   |
+| Relative local path               | `./local-template`                          |
+| Absolute local path               | `/home/user/templates/go-service`           |
+| Explicit local path prefix        | `file:./local-template`                     |
 
 The GitHub shorthand `github:owner/repo:ref` accepts any git ref — a branch name, a tag, or a full commit SHA. HTTPS and SSH sources always use the repository's default branch.
 
 ## Flags
 
-| Flag | Description |
-|------|-------------|
-| `--values <file>` | Load variable values from a JSON or YAML file (`.yaml`/`.yml` → YAML, otherwise JSON) |
-| `--arg <key=value>` | Set a single variable (repeatable) |
-| `--use-defaults` | Accept all defaults without prompting |
-| `--no-hooks` | Skip pre/post-use hooks |
+| Flag                | Description                                                                           |
+|---------------------|---------------------------------------------------------------------------------------|
+| `--values <file>`   | Load variable values from a JSON or YAML file (`.yaml`/`.yml` → YAML, otherwise JSON) |
+| `--arg <key=value>` | Set a single variable (repeatable)                                                    |
+| `--use-defaults`    | Accept all defaults without prompting                                                 |
+| `--no-hooks`        | Skip pre/post-use hooks                                                               |

--- a/docs/content/docs/project-yaml.md
+++ b/docs/content/docs/project-yaml.md
@@ -88,7 +88,7 @@ Hook commands may use `{{ }}` template expressions. To skip hooks for a single r
 
 You can also define hooks as scripts in a `hooks/` directory at the template root:
 
-```
+```text
 my-template/
 ├── project.yml
 ├── template/

--- a/docs/content/docs/project-yaml.md
+++ b/docs/content/docs/project-yaml.md
@@ -9,11 +9,11 @@ It defines the variables your template accepts and their defaults, plus optional
 
 Each variable is a top-level key whose value is the default. The prompt type is inferred from the YAML value type:
 
-| YAML value | Prompt |
-|------------|--------|
-| `"my-app"` (string) | Text input |
-| `false` / `true` (bool) | Yes/No confirm |
-| `["MIT", "Apache-2.0"]` (array) | Select list |
+| YAML value                      | Prompt         |
+|---------------------------------|----------------|
+| `"my-app"` (string)             | Text input     |
+| `false` / `true` (bool)         | Yes/No confirm |
+| `["MIT", "Apache-2.0"]` (array) | Select list    |
 
 For select lists, the first option is the default — it is pre-selected when prompting interactively and chosen automatically when using `--use-defaults`.
 
@@ -53,14 +53,14 @@ __specs__version: ^0.1.0
 
 The value is any valid [Masterminds/semver](https://github.com/Masterminds/semver) constraint string — both lower and upper bounds are supported:
 
-| Value | Meaning |
-|-------|---------|
-| `0.1.0` | exactly `0.1.0` |
-| `^0.1.0` | `>= 0.1.0, < 0.2.0` |
-| `^1.1.1` | `>= 1.1.1, < 2.0.0` |
-| `~0.1.0` | `>= 0.1.0, < 0.2.0` |
-| `>= 0.1.0` | `>= 0.1.0` |
-| `>= 0.1.0, < 2.0` | explicit range |
+| Value             | Meaning             |
+|-------------------|---------------------|
+| `0.1.0`           | exactly `0.1.0`     |
+| `^0.1.0`          | `>= 0.1.0, < 0.2.0` |
+| `^1.1.1`          | `>= 1.1.1, < 2.0.0` |
+| `~0.1.0`          | `>= 0.1.0, < 0.2.0` |
+| `>= 0.1.0`        | `>= 0.1.0`          |
+| `>= 0.1.0, < 2.0` | explicit range      |
 
 A development build (version `dev`, the default when building from source) skips the check so contributors are never locked out. The key is reserved and never exposed as a template variable. `specs template save` intentionally does **not** run the check — you can save a newer template on an older CLI for later use.
 

--- a/docs/content/docs/storage.md
+++ b/docs/content/docs/storage.md
@@ -6,16 +6,18 @@ next: /docs/architecture
 
 Templates are stored under the platform config directory. The location respects `$XDG_CONFIG_HOME` if set.
 
-**macOS**
-```
+## macOS
+
+```text
 ~/Library/Application Support/specs/
 └── templates/
     ├── my-template/
     └── another-template/
 ```
 
-**Linux**
-```
+## Linux
+
+```text
 ~/.config/specs/
 └── templates/
     ├── my-template/

--- a/docs/content/docs/template-functions.md
+++ b/docs/content/docs/template-functions.md
@@ -7,13 +7,13 @@ Templates have access to 200+ functions provided by [Sprout](https://github.com/
 
 ## Specs functions
 
-| Function | Signature | Description |
-|----------|-----------|-------------|
-| `hostname` | `hostname` → `string` | System hostname |
-| `username` | `username` → `string` | Current OS username |
-| `toBinary` | `toBinary <int>` → `string` | Integer to binary string |
-| `formatFilesize` | `formatFilesize <bytes>` → `string` | Human-readable file size (e.g. `"1.0 MB"`) |
-| `password` | `password <length> <digits> <symbols> <noUpper> <allowRepeat>` → `string` | Generate a secure random password |
+| Function         | Signature                                                                 | Description                                |
+|------------------|---------------------------------------------------------------------------|--------------------------------------------|
+| `hostname`       | `hostname` → `string`                                                     | System hostname                            |
+| `username`       | `username` → `string`                                                     | Current OS username                        |
+| `toBinary`       | `toBinary <int>` → `string`                                               | Integer to binary string                   |
+| `formatFilesize` | `formatFilesize <bytes>` → `string`                                       | Human-readable file size (e.g. `"1.0 MB"`) |
+| `password`       | `password <length> <digits> <symbols> <noUpper> <allowRepeat>` → `string` | Generate a secure random password          |
 
 ```
 Default registry: {{ hostname }}.azurecr.io
@@ -23,22 +23,22 @@ Secret key: {{ password 32 4 4 false false }}
 
 ## Sprout function categories
 
-| Category | Example functions |
-|----------|-------------------|
-| **Strings** | `toUpper`, `toLower`, `toPascalCase`, `toSnakeCase`, `toKebabCase`, `trim`, `replace`, `contains`, `repeat` |
-| **Encoding** | `base64Encode`, `base64Decode`, `toJson`, `fromJson`, `toYaml`, `fromYaml` |
-| **Regex** | `regexMatch`, `regexFind`, `regexReplaceAll` |
-| **Collections** | `list`, `dict`, `append`, `prepend`, `uniq`, `keys`, `values`, `merge` |
-| **Date & time** | `now`, `date`, `dateModify`, `dateAgo`, `duration` |
-| **Identity** | `uuidv4`, `uuidv5` |
-| **Crypto** | `sha256sum`, `sha1sum`, `md5sum`, `bcrypt` |
-| **Numeric** | `add`, `sub`, `mul`, `div`, `mod`, `floor`, `ceil`, `round` |
-| **Semver** | `semver`, `semverCompare` |
-| **Network** | `getHostByName` |
-| **Random** | `randInt`, `randAlpha`, `randAlphaNum`, `randAscii` |
-| **Reflection** | `typeOf`, `kindOf`, `kindIs` |
-| **Environment** | `env`, `expandenv` *(disabled in `--safe-mode`)* |
-| **Filesystem** | `osBase`, `osDir`, `osExt` *(disabled in `--safe-mode`)* |
+| Category        | Example functions                                                                                           |
+|-----------------|-------------------------------------------------------------------------------------------------------------|
+| **Strings**     | `toUpper`, `toLower`, `toPascalCase`, `toSnakeCase`, `toKebabCase`, `trim`, `replace`, `contains`, `repeat` |
+| **Encoding**    | `base64Encode`, `base64Decode`, `toJson`, `fromJson`, `toYaml`, `fromYaml`                                  |
+| **Regex**       | `regexMatch`, `regexFind`, `regexReplaceAll`                                                                |
+| **Collections** | `list`, `dict`, `append`, `prepend`, `uniq`, `keys`, `values`, `merge`                                      |
+| **Date & time** | `now`, `date`, `dateModify`, `dateAgo`, `duration`                                                          |
+| **Identity**    | `uuidv4`, `uuidv5`                                                                                          |
+| **Crypto**      | `sha256sum`, `sha1sum`, `md5sum`, `bcrypt`                                                                  |
+| **Numeric**     | `add`, `sub`, `mul`, `div`, `mod`, `floor`, `ceil`, `round`                                                 |
+| **Semver**      | `semver`, `semverCompare`                                                                                   |
+| **Network**     | `getHostByName`                                                                                             |
+| **Random**      | `randInt`, `randAlpha`, `randAlphaNum`, `randAscii`                                                         |
+| **Reflection**  | `typeOf`, `kindOf`, `kindIs`                                                                                |
+| **Environment** | `env`, `expandenv` *(disabled in `--safe-mode`)*                                                            |
+| **Filesystem**  | `osBase`, `osDir`, `osExt` *(disabled in `--safe-mode`)*                                                    |
 
 > **Note:** Sprout uses Go-convention camelCase names. If you're migrating from sprig, see the [rename table](https://docs.gosprout.dev) for the full mapping.
 

--- a/docs/content/docs/template-functions.md
+++ b/docs/content/docs/template-functions.md
@@ -15,7 +15,7 @@ Templates have access to 200+ functions provided by [Sprout](https://github.com/
 | `formatFilesize` | `formatFilesize <bytes>` → `string`                                       | Human-readable file size (e.g. `"1.0 MB"`) |
 | `password`       | `password <length> <digits> <symbols> <noUpper> <allowRepeat>` → `string` | Generate a secure random password          |
 
-```
+```text
 Default registry: {{ hostname }}.azurecr.io
 Author: {{ username }}
 Secret key: {{ password 32 4 4 false false }}

--- a/docs/content/docs/template-structure.md
+++ b/docs/content/docs/template-structure.md
@@ -49,9 +49,9 @@ With `[[ ]]` configured, `{{ }}` in your template files passes through unchanged
 
 Keys prefixed with `__` in the project file are reserved by `specs` and are never exposed as template variables:
 
-| Key | Purpose |
-|-----|---------|
-| `__delimiters` | Override the default `{{ }}` delimiters (see above). |
+| Key                | Purpose                                                                                                                                                                                                                                                                                                                                    |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `__delimiters`     | Override the default `{{ }}` delimiters (see above).                                                                                                                                                                                                                                                                                       |
 | `__specs__version` | Declare a semver constraint on the `specs` CLI version required to use the template, e.g. `__specs__version: ^0.1.0`. `specs use` and `specs template use` refuse to run the template when the running binary does not satisfy the constraint (development builds are exempt). See _The project file_ page for accepted constraint shapes. |
 
 The whole `__` namespace is reserved. You cannot define a variable or computed value whose name
@@ -86,15 +86,15 @@ dist/**
 
 The `<source>` argument in `specs use` and `specs template download` accepts:
 
-| Format | Example |
-|--------|---------|
-| GitHub shorthand | `github:user/repo` |
-| GitHub + branch | `github:user/repo:main` |
-| HTTPS URL | `https://github.com/user/repo` |
-| SSH (SCP-style) | `git@github.com:user/repo` |
-| SSH URL | `ssh://git@github.com/user/repo` |
-| Local path | `./path/to/template` |
-| Local (explicit) | `file:./path/to/template` |
+| Format           | Example                          |
+|------------------|----------------------------------|
+| GitHub shorthand | `github:user/repo`               |
+| GitHub + branch  | `github:user/repo:main`          |
+| HTTPS URL        | `https://github.com/user/repo`   |
+| SSH (SCP-style)  | `git@github.com:user/repo`       |
+| SSH URL          | `ssh://git@github.com/user/repo` |
+| Local path       | `./path/to/template`             |
+| Local (explicit) | `file:./path/to/template`        |
 
 Local paths are only accepted by `specs use`. To register a local directory as a named template, use `specs template save` instead.
 

--- a/docs/content/docs/template-structure.md
+++ b/docs/content/docs/template-structure.md
@@ -6,7 +6,7 @@ prev: /docs/commands
 
 A template is a directory with this layout:
 
-```
+```text
 my-template/
 ├── project.yml         # Variable schema, defaults, and hooks
 └── template/           # Files and directories to render
@@ -21,7 +21,7 @@ Both a project file (`project.yml`) and a `template/` directory are required.
 
 Templates use `{{ }}` by default — standard Go `text/template` syntax:
 
-```
+```text
 Hello, {{ .projectName }}!
 ```
 
@@ -29,7 +29,7 @@ All standard Go template syntax works inside `{{ }}`, including `if`, `range`, `
 
 Directory and file names are also templated:
 
-```
+```text
 {{ .projectName }}/
   {{ if .useDocker }}Dockerfile{{ end }}
   main.go
@@ -74,7 +74,7 @@ will remain executable in every scaffolded project.
 
 Create a `.specsverbatim` file in the template root to list glob patterns for files that should be copied as-is without template rendering:
 
-```
+```text
 *.png
 *.jpg
 *.gif

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -34,12 +34,12 @@ GoReleaser sets `Version` to the Git tag (e.g. `1.2.3`) automatically through `-
 
 ## Target Platforms
 
-| OS | Architecture |
-|----|-------------|
-| `linux` | `amd64` |
-| `linux` | `arm64` |
-| `darwin` | `amd64` |
-| `darwin` | `arm64` |
+| OS       | Architecture |
+|----------|--------------|
+| `linux`  | `amd64`      |
+| `linux`  | `arm64`      |
+| `darwin` | `amd64`      |
+| `darwin` | `arm64`      |
 
 ---
 
@@ -155,32 +155,32 @@ brew install --cask specs
 
 **Trigger:** push and pull_request on any branch.
 
-| Step | Command |
-|------|---------|
-| Checkout | `actions/checkout` with `fetch-depth: 0` |
-| Setup Go | `actions/setup-go` pinned to `go.mod` version |
+| Step          | Command                                       |
+|---------------|-----------------------------------------------|
+| Checkout      | `actions/checkout` with `fetch-depth: 0`      |
+| Setup Go      | `actions/setup-go` pinned to `go.mod` version |
 | Cache modules | `actions/cache` on Go module and build caches |
-| Vet | `go vet ./...` |
-| Test | `go test -race -count=1 ./...` |
-| Build (smoke) | `go build -o /dev/null .` |
+| Vet           | `go vet ./...`                                |
+| Test          | `go test -race -count=1 ./...`                |
+| Build (smoke) | `go build -o /dev/null .`                     |
 
 ### Release workflow — `release.yml`
 
 **Trigger:** push of a tag matching `v*`.
 
-| Step | Detail |
-|------|--------|
-| Checkout | `fetch-depth: 0` — GoReleaser needs all tags and commits |
-| Setup Go | same version as `go.mod` |
-| Cache modules | same as CI |
-| Run GoReleaser | `goreleaser/goreleaser-action` |
+| Step           | Detail                                                   |
+|----------------|----------------------------------------------------------|
+| Checkout       | `fetch-depth: 0` — GoReleaser needs all tags and commits |
+| Setup Go       | same version as `go.mod`                                 |
+| Cache modules  | same as CI                                               |
+| Run GoReleaser | `goreleaser/goreleaser-action`                           |
 
 Required secrets:
 
-| Secret | Purpose |
-|--------|---------|
-| `GITHUB_TOKEN` | Built-in; used by GoReleaser to create GitHub Release |
-| `HOMEBREW_TAP_GITHUB_TOKEN` | PAT with `contents: write` on `specsnl/homebrew-tap` |
+| Secret                      | Purpose                                               |
+|-----------------------------|-------------------------------------------------------|
+| `GITHUB_TOKEN`              | Built-in; used by GoReleaser to create GitHub Release |
+| `HOMEBREW_TAP_GITHUB_TOKEN` | PAT with `contents: write` on `specsnl/homebrew-tap`  |
 
 The release workflow needs `permissions: contents: write`.
 

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -24,7 +24,7 @@ GoReleaser runs only in the release workflow — not needed for local developmen
 
 ## Version Injection
 
-```
+```text
 -X github.com/specsnl/specs-cli/internal/cmd.Version=<version>
 ```
 
@@ -117,7 +117,7 @@ A separate public repository is required: `github.com/specsnl/homebrew-tap`.
 
 Structure after first release:
 
-```
+```text
 homebrew-tap/
   Casks/
     specs.rb     ← generated and committed by GoReleaser on every release
@@ -203,13 +203,16 @@ Binaries and archives land in `dist/` for inspection.
 2. Release notes are ready.
 3. `go.mod` / `go.sum` are committed and `go mod tidy` has been run.
 4. Tag and push:
+
    ```shell
    git tag v1.0.0
    git push origin v1.0.0
    ```
+
 5. Verify the GitHub Release was created.
 6. Verify the Homebrew cask was updated in `specsnl/homebrew-tap`.
 7. Test the Homebrew install on a clean machine:
+
    ```shell
    brew update && brew upgrade --cask specs
    ```

--- a/plan.md
+++ b/plan.md
@@ -41,6 +41,7 @@ level changes from `--debug` still need to mutate the live handler.
 ### 1. Logger plumbing collapse
 
 **`pkg/cmd/app.go`** (`pkg/cmd/app.go:49-99`)
+
 - Remove the `Logger *slog.Logger` field from `App`.
 - `NewApp()` no longer stores a logger pointer; it builds the default handler and
   calls `slog.SetDefault(slog.New(handler))` directly. The `LevelVar` stays on `App`
@@ -50,30 +51,36 @@ level changes from `--debug` still need to mutate the live handler.
 - Drop the `templateGet` helper — call `pkgtemplate.Get(root, cfg)` directly.
 
 **`pkg/cmd/root.go`** (`pkg/cmd/root.go:33-66`)
+
 - In `PersistentPreRunE`, when `--debug --output=json` switches the handler,
   call `slog.SetDefault(slog.New(slog.NewJSONHandler(cmd.ErrOrStderr(), ...)))`
   instead of mutating `app.Logger`. Drop the trailing standalone `slog.SetDefault`
   (it becomes redundant).
 
 **`pkg/template/template.go`** (`pkg/template/template.go:65-145, 165-237`)
+
 - `Get(templateRoot, cfg)` — drop the `logger *slog.Logger` parameter.
 - Remove the `logger` field from `Template` struct.
 - Replace every `logger.X(...)` / `t.logger.X(...)` with `slog.X(...)`.
 
 **`pkg/template/context.go`** (`pkg/template/context.go:58-102`)
+
 - `ApplyComputed(ctx, defs, funcMap, delims)` — drop the logger parameter.
 - Use `slog.Debug(...)` directly.
 
 **`pkg/template/functions.go`** (the sprout `WithLogger` call site)
+
 - Pass `slog.Default()` to `sprout.WithLogger()` (sprout's API expects a `*slog.Logger`).
 
 **`pkg/hooks/hooks.go`** (`pkg/hooks/hooks.go:18-115`)
+
 - `Load(templateRoot, projectConfig, envPrefix)` — drop the logger parameter.
 - Remove the `logger *slog.Logger` field from `Hooks`.
 - Remove the `if logger == nil { logger = slog.Default() }` fallback in `Run`.
 - All `logger.Debug(...)` → `slog.Debug(...)`.
 
 **`pkg/cmd/template_use.go`** (`pkg/cmd/template_use.go:71-141, 200-340`)
+
 - Remove `a.Logger` arguments from `pkgtemplate.Get`, `hooks.Load`,
   `pkgtemplate.ApplyComputed`, `promptContext`, `runPromptPass`.
 - `promptContext` and `runPromptPass` lose their `logger *slog.Logger` parameters;
@@ -81,9 +88,11 @@ level changes from `--debug` still need to mutate the live handler.
 
 **`pkg/cmd/template_list.go`**, **`template_update.go`**, **`template_download.go`**,
 **`use.go`**
+
 - `app.Logger.X(...)` → `slog.X(...)`.
 
 **`pkg/registry/registry.go`** (`pkg/registry/registry.go:40-104`)
+
 - Already uses `slog.Default().X(...)`. Replace with package-level `slog.X(...)`
   for consistency with the rest of the codebase.
 
@@ -96,6 +105,7 @@ level changes from `--debug` still need to mutate the live handler.
 - `CheckRemoteContext` (`pkg/util/git/git.go:290`): debug log on entry with `repo`, `branch`, `dest`; debug log on exit with `up_to_date`, `latest_version`, `error_kind`.
 
 Once instrumented, **remove the duplicated logs** at the call sites:
+
 - `pkg/cmd/template_download.go:53-63` (clone + describe)
 - `pkg/cmd/use.go` (clone)
 - `pkg/cmd/template_list.go:78-86` (`checking remote status` + `remote status result`)
@@ -117,6 +127,7 @@ signature so `result, _ := ...` patterns disappear and the contract matches real
 ### 4. Add logging in `registry.Upgrade()` (review #4)
 
 `pkg/registry/registry.go:65-104`:
+
 - Log entry: `slog.Debug("upgrade start", "template", name)`.
 - Log the resolved `targetRef` after `CheckRemote`: `slog.Debug("upgrade target", "template", name, "repo", meta.Repository, "branch", meta.Branch, "target_ref", targetRef, "latest_version", result.LatestVersion)`.
 - Log the status file removal: `if err := os.Remove(...); err != nil && !os.IsNotExist(err) { slog.Debug("removing stale status file failed", "template", name, "error", err) }`.
@@ -144,6 +155,7 @@ Standardize on this final key set:
 | `error`    | Underlying error (formatted as `%v`)                                                      |
 
 Replace mismatched uses:
+
 - `pkg/template/template.go:92, 117, 130, 163` — `"root", templateRoot` → `"template", templateRoot`.
 - `pkg/cmd/template_list.go:48, 53, 77, 80-86, 94, 101` — `"name"` → `"template"`.
 - `pkg/cmd/template_update.go:43, 51, 53-58, 96` — `"name"` → `"template"`.
@@ -152,6 +164,7 @@ Replace mismatched uses:
 ### 6. Prompt-source semantics — log final winner only (review #6)
 
 Current behavior in `template_use.go`:
+
 - Line 96 logs `source="values_file"` for every key in the values file.
 - Line 108 logs `source="arg_flag"` for `--arg` keys.
 - Line 119 logs `source="default"` for non-provided keys (when `--use-defaults`).
@@ -175,6 +188,7 @@ each key.
 
 Audit every `LoadMetadata`/`LoadStatus` caller and ensure every error path logs at
 debug:
+
 - `pkg/cmd/template_list.go:45, 50` ✓ already logs
 - `pkg/cmd/template_update.go:43, 95` ✓ already logs
 - `pkg/registry/registry.go:43, 50, 73` ✓ already logs
@@ -182,12 +196,14 @@ debug:
 - Verify no other callers exist via `Grep "LoadStatus\|LoadMetadata"`.
 
 Also instrument the two currently-swallowed file mutations:
+
 - `pkg/cmd/template_list.go:101`: `_ = pkgtemplate.SaveStatus(...)` → log on error.
 - `pkg/cmd/template_update.go:64`: same.
 
 ### 8. Repo-wide audit of `, _ :=` and `_ = err` (review #9)
 
 After the targeted fixes above, run a sweep:
+
 - `Grep -n ", _ :=" pkg` and `Grep -n "_ = " pkg` (Go files).
 - For each hit, decide: (a) intentional discard, leave alone; (b) diagnostic value,
   add `slog.Debug(...)`; (c) actual bug, propagate the error.
@@ -251,7 +267,7 @@ flag semantics are unchanged; no update expected, but spot-check to confirm.
 
 ## Critical files (final list)
 
-```
+```text
 pkg/cmd/app.go
 pkg/cmd/root.go
 pkg/cmd/template_use.go

--- a/plan.md
+++ b/plan.md
@@ -128,20 +128,20 @@ signature so `result, _ := ...` patterns disappear and the contract matches real
 
 Standardize on this final key set:
 
-| Key       | Meaning                                                                |
-|-----------|------------------------------------------------------------------------|
-| `template`| Registered template name (e.g. `"minimal"`) — primary user identifier  |
-| `path`    | Template-relative source path of a file (e.g. `"src/foo.go"`)          |
-| `dest`    | Absolute destination path on the filesystem                            |
-| `repo`    | Remote repository URL                                                  |
-| `branch`  | Git branch or tag ref                                                  |
-| `commit`  | Full git commit SHA                                                    |
-| `version` | git-describe-style version string                                      |
-| `trigger` | Hook trigger name (`pre-use`, `post-use`)                              |
-| `key`     | Context variable name                                                  |
-| `source`  | How a context value was provided (`default`/`prompt`/`values_file`/`arg_flag`/`computed`) |
-| `action`  | File decision (`render`/`verbatim`/`skip`)                             |
-| `error`   | Underlying error (formatted as `%v`)                                   |
+| Key        | Meaning                                                                                   |
+|------------|-------------------------------------------------------------------------------------------|
+| `template` | Registered template name (e.g. `"minimal"`) — primary user identifier                     |
+| `path`     | Template-relative source path of a file (e.g. `"src/foo.go"`)                             |
+| `dest`     | Absolute destination path on the filesystem                                               |
+| `repo`     | Remote repository URL                                                                     |
+| `branch`   | Git branch or tag ref                                                                     |
+| `commit`   | Full git commit SHA                                                                       |
+| `version`  | git-describe-style version string                                                         |
+| `trigger`  | Hook trigger name (`pre-use`, `post-use`)                                                 |
+| `key`      | Context variable name                                                                     |
+| `source`   | How a context value was provided (`default`/`prompt`/`values_file`/`arg_flag`/`computed`) |
+| `action`   | File decision (`render`/`verbatim`/`skip`)                                                |
+| `error`    | Underlying error (formatted as `%v`)                                                      |
 
 Replace mismatched uses:
 - `pkg/template/template.go:92, 117, 130, 163` — `"root", templateRoot` → `"template", templateRoot`.


### PR DESCRIPTION
## Summary
- Add a `Markdown` CI workflow (`.github/workflows/md.yml`) that runs `markdownlint-cli2` on PRs, pushes to `main`, and manual dispatch — gated by a paths filter and a final gate job (adapted from the specs-laravel-project template)
- Add `.markdownlint-cli2.yaml` config (line-length 1000, tables exempt; `ul-style: dash`; inline-HTML allowlist; `first-line-heading` disabled for the README HTML header / CLAUDE.md import; excludes `internal/testdata`)
- Add local Taskfile tasks mirroring the CI check: `task md:check`, `task md:fix`, and `task md:fix-tables`, backed by a new `node` Docker Compose service (`markdown` profile)
- Align all markdown tables repo-wide via `markdown-table-formatter`
- Fix markdown style violations so the linter passes: blank lines around lists/fences, code-block languages, real headings in `storage.md`, and scoped `MD033` disables around intentional HTML in `README.md` and `docs/content/_index.md`
- Document the new tasks in `.github/instructions/executing-commands.md`

## Notes
- `task md:check` reports 0 errors across 23 files; `task md:fix` is idempotent
- `md:fix-tables` enables `dotglob` so hidden dirs (`.github`) are covered too — CI and local runs agree
- Only whitespace/structure changed in the docs — no content edits