### PR TITLE
Fix template update status for local sources and version-stamp the status cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ specs template download github:specsnl/my-template my-template
 specs template use my-template ./my-project
 ```
 
+You can also register a local directory as a template:
+
+```sh
+specs template save ./my-template my-template
+```
+
+### Keeping templates up to date
+
+`specs template list` shows an update `Status` for each registered template:
+
+- **Remote templates** (from `download`) are checked against their git remote.
+- **Local templates** (from `save`) are checked against their **source directory on disk** —
+  `update available` means the source path has moved ahead of what was saved (`source missing`
+  if that path is gone).
+
+`specs template upgrade [name]` applies available updates: remote templates are re-cloned, local
+templates are re-copied from their source path. Cached statuses refresh automatically once older
+than 24 hours or when written by a different `specs` version.
+
 ---
 
 ## The project file

--- a/docs/content/docs/architecture/overview.md
+++ b/docs/content/docs/architecture/overview.md
@@ -53,7 +53,7 @@ specs-cli/
     │   ├── analysis.go           # AST-based conditional variable analysis
     │   ├── cond.go               # Cond interface and implementations
     │   ├── metadata.go           # Metadata struct, JSONTime, LoadMetadata(), SaveMetadata()
-    │   ├── status.go             # TemplateStatus — remote stale-check caching
+    │   ├── status.go             # TemplateStatus — status caching (stale + version + local/remote)
     │   └── validate.go           # template validation helpers
     ├── hooks/                    # hook execution
     │   └── hooks.go              # Load(), Run(), context → env vars
@@ -95,7 +95,7 @@ specs [--version|-v]
 │   │     [--no-hooks]
 │   ├── list|ls
 │   ├── update   [name]                     refresh status cache (all if no name)
-│   ├── upgrade  [name]                     re-clone to latest (all if no name)
+│   ├── upgrade  [name]                     re-clone remote / re-copy local to latest (all if no name)
 │   ├── delete|remove|rm|del <name>...
 │   ├── validate <path>
 │   └── rename|mv <old> <new>
@@ -139,7 +139,7 @@ SSH clones are authenticated automatically via SSH agent or standard key files
 ├── project.yml              # variable schema, defaults, optional inline hooks
 ├── .specsverbatim            # verbatim-copy glob patterns (opt-out from rendering)
 ├── __metadata.json           # written by specs on download/save
-├── __status.json             # remote status cache (written by specs template list)
+├── __status.json             # update-status cache (remote or local source; written by specs template list/update)
 ├── hooks/                    # script-based hooks (mutually exclusive with hooks: in project.yml)
 │   ├── pre-use.sh
 │   └── post-use.sh
@@ -336,6 +336,7 @@ log point is `Debug`, suppressed at the default `Info` level) and is distinct fr
 | `internal/util/git` | `Clone`              | Debug | `repo`, `dest`, `branch` (start and complete)                                              |
 | `internal/util/git` | `Describe`           | Debug | `dest`, `commit`, `version` (or `error` on failure)                                        |
 | `internal/util/git` | `CheckRemoteContext` | Debug | `repo`, `branch`, `dest`, `up_to_date`, `latest_version`, `error_kind`                     |
+| `internal/util/git` | `CheckLocalSource`   | Debug | `source`, `saved_commit`, `saved_version`, `up_to_date`, `latest_version`, `error_kind`    |
 
 ### Consistent attribute keys
 
@@ -398,21 +399,21 @@ func (h *Hooks) Run(trigger, cwd string, ctx map[string]any, funcMap template.Fu
 
 ## Packages Added / Changed vs boilr v1
 
-| Package                  | Status      | Change                                                                                                                                                                          |
-|--------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `internal/specs`         | **new**     | XDG paths, file name constants, sentinel errors, `KindOf()` (replaces `pkg/boilr`)                                                                                              |
-| `internal/registry`      | **new**     | on-disk template store: `Entry`, `Load()`, `Upgrade()`                                                                                                                          |
-| `internal/cmd`           | updated     | new `use.go`, `template_update.go`, `template_upgrade.go`, iterative conditional prompting; no longer reads project files or `__metadata.json` directly                         |
-| `internal/template`      | updated     | configurable delimiters (default `{{ }}`), `context.go`, `verbatim.go`, conditional skip, AST analysis, status; exports `LoadProjectFile()`, `LoadMetadata()`, `SaveMetadata()` |
-| `internal/hooks`         | **new**     | hook loading and execution                                                                                                                                                      |
-| `internal/util/output`   | updated     | lipgloss-based logger + table renderer; `WriteErr` with JSON `error_kind` for known sentinels (replaces tlog + tabular)                                                         |
-| `internal/util/values`   | **new**     | `--values` file (JSON/YAML) and `--arg` flag parsing                                                                                                                            |
-| `internal/host`          | updated     | source format parsing (github:, HTTPS, SSH, local path)                                                                                                                         |
-| `pkg/prompt`             | **removed** | replaced by `huh`                                                                                                                                                               |
-| `pkg/util/tlog`          | **removed** | replaced by `internal/util/output`                                                                                                                                              |
-| `pkg/util/tabular`       | **removed** | replaced by `internal/util/output`                                                                                                                                              |
-| `pkg/util/exec`          | **removed** | no longer needed (hooks use `os/exec` directly)                                                                                                                                 |
-| `internal/util/exit`     | unchanged   |                                                                                                                                                                                 |
-| `internal/util/git`      | updated     | SSH auth, `CheckRemoteContext()` (context-aware), `Describe()` for status tracking; `RemoteCheckResult.Err()` returns typed sentinel errors                                     |
-| `internal/util/osutil`   | updated     | `CopyDir()` recursive copy                                                                                                                                                      |
-| `internal/util/validate` | updated     | `Name()` validator (alphanumeric + hyphens + underscores)                                                                                                                       |
+| Package                  | Status      | Change                                                                                                                                                                                |
+|--------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `internal/specs`         | **new**     | XDG paths, file name constants, sentinel errors, `KindOf()` (replaces `pkg/boilr`)                                                                                                    |
+| `internal/registry`      | **new**     | on-disk template store: `Entry`, `Load()`, `Upgrade()`                                                                                                                                |
+| `internal/cmd`           | updated     | new `use.go`, `template_update.go`, `template_upgrade.go`, iterative conditional prompting; no longer reads project files or `__metadata.json` directly                               |
+| `internal/template`      | updated     | configurable delimiters (default `{{ }}`), `context.go`, `verbatim.go`, conditional skip, AST analysis, status; exports `LoadProjectFile()`, `LoadMetadata()`, `SaveMetadata()`       |
+| `internal/hooks`         | **new**     | hook loading and execution                                                                                                                                                            |
+| `internal/util/output`   | updated     | lipgloss-based logger + table renderer; `WriteErr` with JSON `error_kind` for known sentinels (replaces tlog + tabular)                                                               |
+| `internal/util/values`   | **new**     | `--values` file (JSON/YAML) and `--arg` flag parsing                                                                                                                                  |
+| `internal/host`          | updated     | source format parsing (github:, HTTPS, SSH, local path)                                                                                                                               |
+| `pkg/prompt`             | **removed** | replaced by `huh`                                                                                                                                                                     |
+| `pkg/util/tlog`          | **removed** | replaced by `internal/util/output`                                                                                                                                                    |
+| `pkg/util/tabular`       | **removed** | replaced by `internal/util/output`                                                                                                                                                    |
+| `pkg/util/exec`          | **removed** | no longer needed (hooks use `os/exec` directly)                                                                                                                                       |
+| `internal/util/exit`     | unchanged   |                                                                                                                                                                                       |
+| `internal/util/git`      | updated     | SSH auth, `CheckRemoteContext()` (context-aware), `CheckLocalSource()` (local-path status), `Describe()` for status tracking; `RemoteCheckResult.Err()` returns typed sentinel errors |
+| `internal/util/osutil`   | updated     | `CopyDir()` recursive copy                                                                                                                                                            |
+| `internal/util/validate` | updated     | `Name()` validator (alphanumeric + hyphens + underscores)                                                                                                                             |

--- a/docs/content/docs/architecture/template-engine.md
+++ b/docs/content/docs/architecture/template-engine.md
@@ -493,26 +493,55 @@ Exit codes are a bitmask — multiple conditions combine additively:
 
 ## Template Status Tracking
 
-`__status.json` caches the result of a remote HEAD check per template. The `list` command
-refreshes stale entries (older than 24 hours) concurrently, bounded to at most 8 parallel
-checks via `errgroup.SetLimit(8)`. Each individual check has a 10-second per-remote timeout;
+`__status.json` caches the result of a status check per template. The `list` command
+refreshes entries that need it concurrently, bounded to at most 8 parallel checks via
+`errgroup.SetLimit(8)`. Each individual remote check has a 10-second per-remote timeout;
 the entire refresh phase has a 30-second top-level timeout. Both timeouts use `context.Context`
 propagated from the command, so Ctrl-C cancels in-flight checks immediately.
 The `update` command forces an immediate refresh for one or all templates.
 
 ```go
 type TemplateStatus struct {
-    CheckedAt     JSONTime              // time of last remote check
+    CheckedAt     JSONTime              // time of last check
     IsUpToDate    bool                  // true when no newer version is available (see below)
-    LatestVersion string                // set when a newer semver tag is available
-    ErrorKind     pkggit.CheckErrorKind // "network", "auth", "not-found", "unknown", or ""
+    LatestVersion string                // set when a newer version is available
+    ErrorKind     pkggit.CheckErrorKind // "network", "auth", "not-found", "source-missing", "unknown", or ""
+    SpecsVersion  string                // specs CLI version that wrote this status
 }
 ```
 
 `specs template list` displays a `Status` column with labels: `up-to-date`,
-`update: <version>`, `update available`, `unknown (offline?)`, `auth error`, `not found`.
+`update: <version>`, `update available`, `unknown (offline?)`, `auth error`, `not found`,
+`source missing`.
 
-### How a newer version is determined
+### When a cached status is refreshed
+
+`TemplateStatus.NeedsRefresh(currentVersion)` decides whether the `list` command re-checks a
+cached status. A refresh happens when either:
+
+- the status is **stale** — older than 24 hours (`IsStale`); or
+- the status was written by a **different specs version** — `SpecsVersion` does not match the
+  running binary.
+
+The version guard ensures a status produced by an older binary with different check logic is
+never trusted after an upgrade: a status-detection fix takes effect on the first `list` after
+the upgrade instead of waiting out the 24-hour window. `SpecsVersion` is stamped on every
+status written by `list` and `update`.
+
+### Remote vs local templates
+
+The source of truth depends on how the template was registered:
+
+- **Remote templates** (`Repository` is a git URL) are checked against the remote via
+  `CheckRemoteContext`, which lists the remote refs without modifying the local checkout.
+- **Local templates** (`Repository` is `local:<path>`, from `specs template save`) are checked
+  against the **source directory on disk** via `CheckLocalSource` — never a git remote. The
+  template is behind when the source path's current `git describe` (commit + version) differs
+  from the commit/version recorded in metadata at save time. When the source path no longer
+  exists (or is no longer a git repository) the status is `source-missing`. A local template
+  saved from a non-git directory has no recorded commit and is not tracked.
+
+### How a newer version is determined (remote templates)
 
 `resolveStatus` compares the remote refs against the local checkout using two modes:
 

--- a/docs/content/docs/commands/template.md
+++ b/docs/content/docs/commands/template.md
@@ -7,17 +7,17 @@ Manage a local registry of named templates. Unlike `specs use`, downloaded templ
 
 ## Subcommands
 
-| Subcommand                                   | Description                                                                                                                                                             |
-|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `list` / `ls`                                | List registered templates with update status. Stale statuses (older than 24 hours) are refreshed automatically. Use `--output json` for machine-readable NDJSON output. |
-| `save <path> <name>`                         | Register a local directory as a template                                                                                                                                |
-| `download` / `add <source> <name>`           | Download a remote template and save it to the local registry                                                                                                            |
-| `use <name> <target-dir>`                    | Execute a registered template                                                                                                                                           |
-| `validate <path>`                            | Check if a template directory is valid                                                                                                                                  |
-| `rename` / `mv <old> <new>`                  | Rename a registered template                                                                                                                                            |
-| `delete` / `rm` / `remove` / `del <name>...` | Remove one or more templates from the registry                                                                                                                          |
-| `update [name]`                              | Force-refresh the cached update status; updates all template statuses if no name is given                                                                               |
-| `upgrade [name]`                             | Apply available updates; upgrades all remote templates if no name is given                                                                                              |
+| Subcommand                                   | Description                                                                                                                                                                                                         |
+|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `list` / `ls`                                | List registered templates with update status. Cached statuses are refreshed automatically when older than 24 hours or written by a different specs version. Use `--output json` for machine-readable NDJSON output. |
+| `save <path> <name>`                         | Register a local directory as a template                                                                                                                                                                            |
+| `download` / `add <source> <name>`           | Download a remote template and save it to the local registry                                                                                                                                                        |
+| `use <name> <target-dir>`                    | Execute a registered template                                                                                                                                                                                       |
+| `validate <path>`                            | Check if a template directory is valid                                                                                                                                                                              |
+| `rename` / `mv <old> <new>`                  | Rename a registered template                                                                                                                                                                                        |
+| `delete` / `rm` / `remove` / `del <name>...` | Remove one or more templates from the registry                                                                                                                                                                      |
+| `update [name]`                              | Force-refresh the cached update status; updates all template statuses if no name is given                                                                                                                           |
+| `upgrade [name]`                             | Apply available updates; upgrades all templates if no name is given (remote templates re-clone, local templates re-copy from their source path)                                                                     |
 
 `template use` accepts the same flags as `specs use` (`--values`, `--arg`, `--use-defaults`, `--no-hooks`).
 
@@ -26,3 +26,22 @@ Manage a local registry of named templates. Unlike `specs use`, downloaded templ
 `template download` and `template save` accept `-f` / `--force` to overwrite an existing template with the same name.
 
 For machine-readable `list` output, use the global `--output json` flag (see [Global Flags](global-flags)).
+
+## Update status
+
+The `Status` column reflects where each template's "source of truth" lives:
+
+- **Remote templates** (downloaded from a git URL) are compared against the remote. For tagged
+  templates a newer version means a strictly-greater semver tag; for branch-tracked templates
+  sitting on a released tag the same semver rule applies, otherwise the branch tip is compared.
+- **Local templates** (registered with `save`) are compared against the **source directory on
+  disk**, not a git remote. `update available` means the source path has moved ahead of the
+  commit/version recorded when the template was saved. If the source path no longer exists the
+  status is `source missing`.
+
+Possible `Status` values: `up-to-date`, `update: <version>`, `update available`,
+`unknown (offline?)`, `auth error`, `not found`, `source missing`, `unknown`, `-` (untracked).
+
+Cached statuses are stored per template and re-checked when older than 24 hours **or** when they
+were written by a different `specs` version — so an update to the status-check logic takes effect
+on the next `list` after upgrading the CLI, rather than after the cache expires.

--- a/internal/cmd/template_list.go
+++ b/internal/cmd/template_list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +14,28 @@ import (
 	pkggit "github.com/specsnl/specs-cli/internal/util/git"
 	"golang.org/x/sync/errgroup"
 )
+
+// localRepoPrefix marks a Repository value that refers to a directory on disk
+// (registered via 'specs template save') rather than a remote git URL.
+const localRepoPrefix = "local:"
+
+// isLocalRepo reports whether repo refers to a local source path.
+func isLocalRepo(repo string) bool {
+	return strings.HasPrefix(repo, localRepoPrefix)
+}
+
+// isTrackable reports whether a template carries enough metadata for a status
+// check. A remote template needs a repository and a branch; a local template
+// needs a recorded commit to compare its source path against.
+func isTrackable(meta *pkgtemplate.Metadata) bool {
+	if meta == nil || meta.Repository == "" {
+		return false
+	}
+	if isLocalRepo(meta.Repository) {
+		return meta.Commit != ""
+	}
+	return meta.Branch != ""
+}
 
 func newTemplateListCmd(app *App) *cobra.Command {
 	cmd := &cobra.Command{
@@ -80,24 +103,37 @@ func newTemplateListCmd(app *App) *cobra.Command {
 			eg.SetLimit(maxConcurrency)
 
 			for i, entry := range tmplEntries {
-				if entry.meta == nil || entry.meta.Repository == "" || entry.meta.Branch == "" {
+				if !isTrackable(entry.meta) {
 					continue
 				}
-				if entry.status != nil && !entry.status.IsStale() {
+				// A version change forces a refresh even within the 24h window, so a
+				// status written by an older binary with different check logic is not trusted.
+				if entry.status != nil && !entry.status.NeedsRefresh(Version) {
 					continue
 				}
-				i, name, repo, branch := i, entry.name, entry.meta.Repository, entry.meta.Branch
+				i, name := i, entry.name
+				repo, branch := entry.meta.Repository, entry.meta.Branch
+				commit, version := entry.meta.Commit, entry.meta.Version
+				local := isLocalRepo(repo)
 				eg.Go(func() error {
-					checkCtx, cancelCheck := context.WithTimeout(egCtx, app.checkTimeout)
-					defer cancelCheck()
 					root := specs.TemplatePath(name)
-					// git layer logs the check-remote start/result
-					result := app.checkRemoteFn(checkCtx, root, repo, branch)
+					var result pkggit.RemoteCheckResult
+					if local {
+						// Local templates compare against the source path on disk, not a
+						// git remote. The git layer logs the check-local start/result.
+						result = pkggit.CheckLocalSource(strings.TrimPrefix(repo, localRepoPrefix), commit, version)
+					} else {
+						checkCtx, cancelCheck := context.WithTimeout(egCtx, app.checkTimeout)
+						defer cancelCheck()
+						// git layer logs the check-remote start/result
+						result = app.checkRemoteFn(checkCtx, root, repo, branch)
+					}
 					newStatus := &pkgtemplate.TemplateStatus{
 						CheckedAt:     pkgtemplate.JSONTime{Time: time.Now().UTC()},
 						IsUpToDate:    result.IsUpToDate,
 						LatestVersion: result.LatestVersion,
 						ErrorKind:     result.ErrorKind,
+						SpecsVersion:  Version,
 					}
 					if err := pkgtemplate.SaveStatus(root, newStatus); err != nil {
 						slog.Debug("failed to save template status", "template", name, "error", err)
@@ -126,8 +162,7 @@ func newTemplateListCmd(app *App) *cobra.Command {
 						version = entry.meta.Version
 					}
 				}
-				hasRemote := entry.meta != nil && entry.meta.Repository != "" && entry.meta.Branch != ""
-				statusStr := statusLabel(entry.status, hasRemote)
+				statusStr := statusLabel(entry.status, isTrackable(entry.meta))
 				rows = append(rows, []string{entry.name, repo, version, statusStr, created, updated})
 			}
 
@@ -149,9 +184,11 @@ func newTemplateListCmd(app *App) *cobra.Command {
 	return cmd
 }
 
-// statusLabel returns the Status column string for a template.
-func statusLabel(status *pkgtemplate.TemplateStatus, hasRemote bool) string {
-	if !hasRemote {
+// statusLabel returns the Status column string for a template. tracked reports
+// whether the template has a source (remote branch or local path) whose status
+// can be checked; untracked templates always render as "-".
+func statusLabel(status *pkgtemplate.TemplateStatus, tracked bool) string {
+	if !tracked {
 		return "-"
 	}
 	if status == nil {
@@ -164,6 +201,8 @@ func statusLabel(status *pkgtemplate.TemplateStatus, hasRemote bool) string {
 		return "auth error"
 	case pkggit.CheckErrorNotFound:
 		return "not found"
+	case pkggit.CheckErrorSourceMissing:
+		return "source missing"
 	case pkggit.CheckErrorUnknown:
 		return "check failed"
 	}

--- a/internal/cmd/template_list_test.go
+++ b/internal/cmd/template_list_test.go
@@ -196,10 +196,11 @@ func TestList_StatusColumn_FreshUpToDate(t *testing.T) {
 	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
-	// Write a fresh status so no network call is made.
+	// Write a fresh status stamped with the current CLI version so no network call is made.
 	status := &pkgtemplate.TemplateStatus{
-		CheckedAt:  pkgtemplate.JSONTime{Time: time.Now()},
-		IsUpToDate: true,
+		CheckedAt:    pkgtemplate.JSONTime{Time: time.Now()},
+		IsUpToDate:   true,
+		SpecsVersion: Version,
 	}
 	if err := pkgtemplate.SaveStatus(tmplDir, status); err != nil {
 		t.Fatal(err)
@@ -226,6 +227,7 @@ func TestStatusLabel(t *testing.T) {
 		{"network error", &pkgtemplate.TemplateStatus{ErrorKind: pkggit.CheckErrorNetwork}, true, "unknown (offline?)"},
 		{"auth error", &pkgtemplate.TemplateStatus{ErrorKind: pkggit.CheckErrorAuth}, true, "auth error"},
 		{"not found", &pkgtemplate.TemplateStatus{ErrorKind: pkggit.CheckErrorNotFound}, true, "not found"},
+		{"source missing", &pkgtemplate.TemplateStatus{ErrorKind: pkggit.CheckErrorSourceMissing}, true, "source missing"},
 		{"unknown error", &pkgtemplate.TemplateStatus{ErrorKind: pkggit.CheckErrorUnknown}, true, "check failed"},
 		{"up-to-date", &pkgtemplate.TemplateStatus{IsUpToDate: true}, true, "up-to-date"},
 		{"update with version", &pkgtemplate.TemplateStatus{LatestVersion: "v2.0.0"}, true, "update: v2.0.0"},

--- a/internal/cmd/template_local_test.go
+++ b/internal/cmd/template_local_test.go
@@ -1,0 +1,151 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	pkgtemplate "github.com/specsnl/specs-cli/internal/template"
+	pkggit "github.com/specsnl/specs-cli/internal/util/git"
+)
+
+var localSig = &object.Signature{Name: "t", Email: "t@t.com", When: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}
+
+func localCommit(t *testing.T, repo *gogit.Repository, dir, label string) plumbing.Hash {
+	t.Helper()
+	wt, _ := repo.Worktree()
+	if err := os.WriteFile(filepath.Join(dir, label+".txt"), []byte(label), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(label + ".txt"); err != nil {
+		t.Fatal(err)
+	}
+	h, err := wt.Commit(label, &gogit.CommitOptions{Author: localSig})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+// makeLocalTemplate creates a source git repo (tagged 1.0.0) and registers it as a
+// "local:" template, returning (sourcePath, templateDir).
+func makeLocalTemplate(t *testing.T, registryDir, name string) (string, *gogit.Repository, string) {
+	t.Helper()
+	src := t.TempDir()
+	repo, err := gogit.PlainInit(src, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	h := localCommit(t, repo, src, "init")
+	if _, err := repo.CreateTag("1.0.0", h, nil); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+	desc, err := pkggit.Describe(src)
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+
+	tmplDir := filepath.Join(registryDir, name)
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := pkgtemplate.SaveMetadata(tmplDir, name, "local:"+src, "", desc.Commit, desc.Version, now, now); err != nil {
+		t.Fatalf("SaveMetadata: %v", err)
+	}
+	return src, repo, tmplDir
+}
+
+func TestList_LocalSource_UpToDate(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	makeLocalTemplate(t, registryDir, "loc")
+
+	out, err := executeCmd("template", "list")
+	if err != nil {
+		t.Fatalf("template list: %v", err)
+	}
+	if !strings.Contains(out, "up-to-date") {
+		t.Errorf("expected 'up-to-date' for unchanged local source, got: %q", out)
+	}
+}
+
+func TestList_LocalSource_Advanced(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	src, repo, _ := makeLocalTemplate(t, registryDir, "loc")
+
+	// Source path moves ahead of what was saved.
+	localCommit(t, repo, src, "second")
+
+	out, err := executeCmd("template", "list")
+	if err != nil {
+		t.Fatalf("template list: %v", err)
+	}
+	if !strings.Contains(out, "update") {
+		t.Errorf("expected an 'update' status when local source advanced, got: %q", out)
+	}
+	if strings.Contains(out, "up-to-date") {
+		t.Errorf("expected NOT up-to-date when local source advanced, got: %q", out)
+	}
+}
+
+func TestList_LocalSource_Missing(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	src, _, _ := makeLocalTemplate(t, registryDir, "loc")
+
+	if err := os.RemoveAll(src); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := executeCmd("template", "list")
+	if err != nil {
+		t.Fatalf("template list: %v", err)
+	}
+	if !strings.Contains(out, "source missing") {
+		t.Errorf("expected 'source missing' when local source path is gone, got: %q", out)
+	}
+}
+
+// TestList_VersionMismatchForcesRefresh verifies that a fresh status written by a
+// different specs version is re-checked rather than trusted.
+func TestList_VersionMismatchForcesRefresh(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	tmplDir := filepath.Join(registryDir, "remote-tpl")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := pkgtemplate.SaveMetadata(tmplDir, "remote-tpl", "https://example.com/repo", "main", "", "", time.Now().UTC(), time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	// Fresh (not stale) status, but written by a different/older version.
+	seeded := &pkgtemplate.TemplateStatus{
+		CheckedAt:    pkgtemplate.JSONTime{Time: time.Now()},
+		IsUpToDate:   false,
+		SpecsVersion: "0.0.1-old",
+	}
+	if err := pkgtemplate.SaveStatus(tmplDir, seeded); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Bool
+	fake := func(_ context.Context, _, _, _ string) pkggit.RemoteCheckResult {
+		called.Store(true)
+		return pkggit.RemoteCheckResult{IsUpToDate: true}
+	}
+	out, err := executeCmdWithCheckFn(fake, "template", "list")
+	if err != nil {
+		t.Fatalf("template list: %v", err)
+	}
+	if !called.Load() {
+		t.Error("expected a refresh (checkRemoteFn call) when stored SpecsVersion differs")
+	}
+	if !strings.Contains(out, "up-to-date") {
+		t.Errorf("expected refreshed 'up-to-date' status, got: %q", out)
+	}
+}

--- a/internal/cmd/template_update.go
+++ b/internal/cmd/template_update.go
@@ -47,33 +47,45 @@ func newTemplateUpdateCmd(app *App) *cobra.Command {
 				if err != nil {
 					slog.Debug("failed to parse template metadata", "template", name, "error", err)
 				}
-				if meta == nil || meta.Repository == "" || strings.HasPrefix(meta.Repository, "local:") {
+				if meta == nil || meta.Repository == "" {
 					continue
 				}
 
-				branch := meta.Branch
-				if branch == "" {
-					b, err := pkggit.CurrentBranch(root)
-					if err != nil {
-						slog.Debug("could not resolve branch from local HEAD, skipping", "template", name, "error", err)
+				var result pkggit.RemoteCheckResult
+				if isLocalRepo(meta.Repository) {
+					if meta.Commit == "" {
+						// Nothing recorded to compare the source path against.
 						continue
 					}
-					branch = b
-					// Persist the resolved branch so future runs skip this fallback.
-					if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, branch, meta.Commit, meta.Version, meta.Created.Time, meta.Updated.Time); err != nil {
-						slog.Debug("failed to persist resolved branch", "template", name, "error", err)
+					checkedCount++
+					// git layer logs the check-local start/result
+					result = pkggit.CheckLocalSource(strings.TrimPrefix(meta.Repository, localRepoPrefix), meta.Commit, meta.Version)
+				} else {
+					branch := meta.Branch
+					if branch == "" {
+						b, err := pkggit.CurrentBranch(root)
+						if err != nil {
+							slog.Debug("could not resolve branch from local HEAD, skipping", "template", name, "error", err)
+							continue
+						}
+						branch = b
+						// Persist the resolved branch so future runs skip this fallback.
+						if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, branch, meta.Commit, meta.Version, meta.Created.Time, meta.Updated.Time); err != nil {
+							slog.Debug("failed to persist resolved branch", "template", name, "error", err)
+						}
 					}
-				}
 
-				checkedCount++
-				// git layer logs the check-remote start/result
-				result := pkggit.CheckRemote(root, meta.Repository, branch)
+					checkedCount++
+					// git layer logs the check-remote start/result
+					result = pkggit.CheckRemote(root, meta.Repository, branch)
+				}
 
 				newStatus := &pkgtemplate.TemplateStatus{
 					CheckedAt:     pkgtemplate.JSONTime{Time: time.Now().UTC()},
 					IsUpToDate:    result.IsUpToDate,
 					LatestVersion: result.LatestVersion,
 					ErrorKind:     result.ErrorKind,
+					SpecsVersion:  Version,
 				}
 				if err := pkgtemplate.SaveStatus(root, newStatus); err != nil {
 					slog.Debug("failed to save template status", "template", name, "error", err)
@@ -86,6 +98,8 @@ func newTemplateUpdateCmd(app *App) *cobra.Command {
 					app.Output.Warn("template %q: auth error", name)
 				case pkggit.CheckErrorNotFound:
 					app.Output.Warn("template %q: repository not found", name)
+				case pkggit.CheckErrorSourceMissing:
+					app.Output.Warn("template %q: local source path is missing", name)
 				case pkggit.CheckErrorUnknown:
 					app.Output.Warn("template %q: status check failed", name)
 				default:

--- a/internal/cmd/template_upgrade.go
+++ b/internal/cmd/template_upgrade.go
@@ -46,7 +46,7 @@ func newTemplateUpgradeCmd(app *App) *cobra.Command {
 				}
 				switch {
 				case res.IsLocal:
-					app.Output.Info("template %q is a local template — skipping (no remote branch)", name)
+					app.Output.Info("template %q has no trackable source (no remote branch or git history) — skipping", name)
 				case res.AlreadyUpToDate:
 					app.Output.Info("template %q is already up-to-date", name)
 				default:

--- a/internal/registry/local_upgrade_test.go
+++ b/internal/registry/local_upgrade_test.go
@@ -1,0 +1,148 @@
+package registry_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/specsnl/specs-cli/internal/registry"
+	"github.com/specsnl/specs-cli/internal/specs"
+	pkgtemplate "github.com/specsnl/specs-cli/internal/template"
+	pkggit "github.com/specsnl/specs-cli/internal/util/git"
+	"github.com/specsnl/specs-cli/internal/util/osutil"
+)
+
+var upgradeSig = &object.Signature{Name: "Test", Email: "test@example.com", When: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)}
+
+// newSourceRepo creates a git repo with a single tagged commit and returns its path.
+func newSourceRepo(t *testing.T) (string, *gogit.Repository) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	commitFile(t, repo, dir, "init")
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if _, err := repo.CreateTag("1.0.0", head.Hash(), nil); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+	return dir, repo
+}
+
+func commitFile(t *testing.T, repo *gogit.Repository, dir, label string) plumbing.Hash {
+	t.Helper()
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, label+".txt"), []byte(label), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := wt.Add(label + ".txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	hash, err := wt.Commit(label, &gogit.CommitOptions{Author: upgradeSig})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return hash
+}
+
+// saveLocalTemplate mimics `specs template save`: copies src into the registry and
+// writes metadata with a "local:" repository and the source's describe output.
+func saveLocalTemplate(t *testing.T, registryDir, name, src string) string {
+	t.Helper()
+	dest := filepath.Join(registryDir, name)
+	if err := osutil.CopyDir(src, dest); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+	desc, err := pkggit.Describe(src)
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := pkgtemplate.SaveMetadata(dest, name, "local:"+src, "", desc.Commit, desc.Version, now, now); err != nil {
+		t.Fatalf("SaveMetadata: %v", err)
+	}
+	return dest
+}
+
+func TestUpgrade_LocalGitSource_UpToDate(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	src, _ := newSourceRepo(t)
+	saveLocalTemplate(t, registryDir, "loc", src)
+
+	res, err := registry.Upgrade("loc")
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	if !res.AlreadyUpToDate {
+		t.Errorf("expected AlreadyUpToDate=true when source is unchanged, got %+v", res)
+	}
+	if res.IsLocal {
+		t.Error("expected IsLocal=false for a git-tracked local source")
+	}
+}
+
+func TestUpgrade_LocalGitSource_Advanced(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	src, repo := newSourceRepo(t)
+	dest := saveLocalTemplate(t, registryDir, "loc", src)
+
+	before, _ := pkgtemplate.LoadMetadata(dest)
+
+	// Source advances after save.
+	commitFile(t, repo, src, "second")
+	newDesc, _ := pkggit.Describe(src)
+
+	res, err := registry.Upgrade("loc")
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	if res.AlreadyUpToDate || res.IsLocal {
+		t.Fatalf("expected an actual upgrade, got %+v", res)
+	}
+
+	after, _ := pkgtemplate.LoadMetadata(dest)
+	if after.Commit == before.Commit {
+		t.Error("expected Commit to change after upgrade")
+	}
+	if after.Commit != newDesc.Commit {
+		t.Errorf("Commit = %q, want %q", after.Commit, newDesc.Commit)
+	}
+	if !after.Created.Time.Equal(before.Created.Time) {
+		t.Error("Created should be preserved across upgrade")
+	}
+	// The freshly copied file must be present in the registry.
+	if _, err := os.Stat(filepath.Join(dest, "second.txt")); err != nil {
+		t.Errorf("expected 'second.txt' copied into registry: %v", err)
+	}
+	// Stale status must be removed so it regenerates.
+	if _, err := os.Stat(filepath.Join(dest, specs.StatusFile)); !os.IsNotExist(err) {
+		t.Errorf("expected status file removed after upgrade, stat err = %v", err)
+	}
+}
+
+func TestUpgrade_LocalGitSource_Missing(t *testing.T) {
+	registryDir := withTempRegistry(t)
+	src, _ := newSourceRepo(t)
+	saveLocalTemplate(t, registryDir, "loc", src)
+
+	if err := os.RemoveAll(src); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := registry.Upgrade("loc")
+	if !errors.Is(err, specs.ErrLocalSourceMissing) {
+		t.Errorf("expected ErrLocalSourceMissing, got %v", err)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/specsnl/specs-cli/internal/specs"
 	pkgtemplate "github.com/specsnl/specs-cli/internal/template"
 	pkggit "github.com/specsnl/specs-cli/internal/util/git"
+	"github.com/specsnl/specs-cli/internal/util/osutil"
 )
 
 // Entry represents a registered template with its metadata and cached remote status.
@@ -72,8 +73,11 @@ func Upgrade(name string) (UpgradeResult, error) {
 	if err != nil {
 		slog.Debug("failed to parse template metadata", "template", name, "error", err)
 	}
-	if meta == nil || meta.Repository == "" || strings.HasPrefix(meta.Repository, "local:") {
+	if meta == nil || meta.Repository == "" {
 		return UpgradeResult{IsLocal: true}, nil
+	}
+	if strings.HasPrefix(meta.Repository, "local:") {
+		return upgradeLocal(name, root, meta)
 	}
 
 	branch := meta.Branch
@@ -128,4 +132,49 @@ func Upgrade(name string) (UpgradeResult, error) {
 
 	slog.Debug("upgrade complete", "template", name, "target_ref", targetRef)
 	return UpgradeResult{Repository: meta.Repository, TargetRef: targetRef}, nil
+}
+
+// upgradeLocal re-copies a local template (Repository "local:<path>") from its
+// source directory on disk. A local template with no recorded commit cannot be
+// tracked for changes and is reported as IsLocal (skipped). When the source path
+// no longer exists, ErrLocalSourceMissing is returned. When the source is unchanged
+// the result reports AlreadyUpToDate; otherwise the registry copy is replaced with
+// the current source contents and its metadata refreshed.
+func upgradeLocal(name, root string, meta *pkgtemplate.Metadata) (UpgradeResult, error) {
+	if meta.Commit == "" {
+		// Saved from a non-git directory — no commit to compare, so updates
+		// cannot be detected automatically.
+		return UpgradeResult{IsLocal: true}, nil
+	}
+
+	src := strings.TrimPrefix(meta.Repository, "local:")
+	check := pkggit.CheckLocalSource(src, meta.Commit, meta.Version)
+	if check.ErrorKind == pkggit.CheckErrorSourceMissing {
+		return UpgradeResult{}, fmt.Errorf("%w: %s", specs.ErrLocalSourceMissing, src)
+	}
+	if check.IsUpToDate {
+		return UpgradeResult{AlreadyUpToDate: true}, nil
+	}
+
+	slog.Debug("upgrade local target", "template", name, "source", src, "latest_version", check.LatestVersion)
+
+	if err := os.RemoveAll(root); err != nil {
+		return UpgradeResult{}, err
+	}
+	if err := osutil.CopyDir(src, root); err != nil {
+		return UpgradeResult{}, err
+	}
+
+	desc, _ := pkggit.Describe(root) // errors are logged by the git layer
+	if err := pkgtemplate.SaveMetadata(root, name, meta.Repository, meta.Branch, desc.Commit, desc.Version, meta.Created.Time, time.Now().UTC()); err != nil {
+		return UpgradeResult{}, err
+	}
+
+	// Remove stale status; regenerated on next template list or update.
+	if err := os.Remove(root + "/" + specs.StatusFile); err != nil && !os.IsNotExist(err) {
+		slog.Debug("removing stale status file failed", "template", name, "error", err)
+	}
+
+	slog.Debug("upgrade local complete", "template", name, "source", src)
+	return UpgradeResult{Repository: meta.Repository, TargetRef: src}, nil
 }

--- a/internal/specs/errors.go
+++ b/internal/specs/errors.go
@@ -33,6 +33,10 @@ var (
 	// remote URL (e.g. specs template download).
 	ErrLocalSource = errors.New("source is a local path — use 'specs template save' to register a local template")
 
+	// ErrLocalSourceMissing is returned when a local template's source path (the directory
+	// it was saved from) no longer exists, so its status cannot be checked or upgraded.
+	ErrLocalSourceMissing = errors.New("local source path no longer exists")
+
 	// ErrInvalidComputedDef is returned when a "computed" entry in project.yaml is malformed:
 	// wrong type, value type mismatch, or conflict with a user input key.
 	ErrInvalidComputedDef = errors.New("invalid computed definition")
@@ -78,6 +82,8 @@ func KindOf(err error) string {
 		return "project_file_missing"
 	case errors.Is(err, ErrLocalSource):
 		return "local_source"
+	case errors.Is(err, ErrLocalSourceMissing):
+		return "local_source_missing"
 	case errors.Is(err, ErrInvalidComputedDef):
 		return "invalid_computed_def"
 	case errors.Is(err, ErrCyclicDependency):

--- a/internal/template/status.go
+++ b/internal/template/status.go
@@ -17,11 +17,25 @@ type TemplateStatus struct {
 	IsUpToDate    bool                  `json:"IsUpToDate"`
 	LatestVersion string                `json:"LatestVersion,omitempty"`
 	ErrorKind     pkggit.CheckErrorKind `json:"ErrorKind,omitempty"`
+	// SpecsVersion is the specs CLI version that wrote this status. It lets the
+	// list command detect a status produced by a different (usually older) binary
+	// and force a refresh, so status-check logic fixes take effect immediately after
+	// an upgrade instead of waiting out the 24-hour staleness window.
+	SpecsVersion string `json:"SpecsVersion,omitempty"`
 }
 
 // IsStale returns true when the cached status is older than 24 hours.
 func (s *TemplateStatus) IsStale() bool {
 	return time.Since(s.CheckedAt.Time) > 24*time.Hour
+}
+
+// NeedsRefresh reports whether the cached status should be re-checked. A refresh
+// is needed when the status is stale (see IsStale) or when it was written by a
+// different specs CLI version than currentVersion — the latter ensures a status
+// produced by an older binary with different check logic is not trusted after an
+// upgrade.
+func (s *TemplateStatus) NeedsRefresh(currentVersion string) bool {
+	return s.IsStale() || s.SpecsVersion != currentVersion
 }
 
 // LoadStatus reads __status.json from templateRoot.

--- a/internal/template/status_test.go
+++ b/internal/template/status_test.go
@@ -24,6 +24,52 @@ func TestIsStale_Old(t *testing.T) {
 	}
 }
 
+func TestNeedsRefresh(t *testing.T) {
+	fresh := JSONTime{Time: time.Now().Add(-1 * time.Hour)}
+	stale := JSONTime{Time: time.Now().Add(-25 * time.Hour)}
+
+	tests := []struct {
+		name       string
+		checkedAt  JSONTime
+		version    string
+		current    string
+		wantResult bool
+	}{
+		{"fresh same version", fresh, "1.0.0", "1.0.0", false},
+		{"fresh different version", fresh, "0.9.0", "1.0.0", true},
+		{"fresh empty stored version", fresh, "", "1.0.0", true},
+		{"stale same version", stale, "1.0.0", "1.0.0", true},
+		{"stale different version", stale, "0.9.0", "1.0.0", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &TemplateStatus{CheckedAt: tc.checkedAt, SpecsVersion: tc.version}
+			if got := s.NeedsRefresh(tc.current); got != tc.wantResult {
+				t.Errorf("NeedsRefresh(%q) with stored %q = %v, want %v", tc.current, tc.version, got, tc.wantResult)
+			}
+		})
+	}
+}
+
+func TestStatus_SpecsVersionRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	original := &TemplateStatus{
+		CheckedAt:    JSONTime{Time: time.Now().UTC().Truncate(time.Second)},
+		IsUpToDate:   true,
+		SpecsVersion: "1.2.3",
+	}
+	if err := SaveStatus(dir, original); err != nil {
+		t.Fatalf("SaveStatus: %v", err)
+	}
+	loaded, err := LoadStatus(dir)
+	if err != nil {
+		t.Fatalf("LoadStatus: %v", err)
+	}
+	if loaded.SpecsVersion != "1.2.3" {
+		t.Errorf("SpecsVersion: got %q, want %q", loaded.SpecsVersion, "1.2.3")
+	}
+}
+
 func TestLoadStatus_Missing(t *testing.T) {
 	dir := t.TempDir()
 	s, err := LoadStatus(dir)

--- a/internal/util/git/check_local_test.go
+++ b/internal/util/git/check_local_test.go
@@ -1,0 +1,81 @@
+package git_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	pkggit "github.com/specsnl/specs-cli/internal/util/git"
+)
+
+func TestCheckLocalSource_Missing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	got := pkggit.CheckLocalSource(missing, "abc", "v1.0.0")
+	if got.ErrorKind != pkggit.CheckErrorSourceMissing {
+		t.Errorf("ErrorKind = %q, want %q", got.ErrorKind, pkggit.CheckErrorSourceMissing)
+	}
+}
+
+func TestCheckLocalSource_NotARepo(t *testing.T) {
+	got := pkggit.CheckLocalSource(t.TempDir(), "abc", "v1.0.0")
+	if got.ErrorKind != pkggit.CheckErrorSourceMissing {
+		t.Errorf("ErrorKind = %q, want %q", got.ErrorKind, pkggit.CheckErrorSourceMissing)
+	}
+}
+
+func TestCheckLocalSource_UpToDate(t *testing.T) {
+	dir, repo := initRepo(t)
+	hash := addCommit(t, repo, dir, "init")
+	tagCommit(t, repo, "v1.0.0", hash, false)
+
+	desc, err := pkggit.Describe(dir)
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+
+	got := pkggit.CheckLocalSource(dir, desc.Commit, desc.Version)
+	if got.ErrorKind != pkggit.CheckErrorNone {
+		t.Fatalf("ErrorKind = %q, want none", got.ErrorKind)
+	}
+	if !got.IsUpToDate {
+		t.Errorf("IsUpToDate = false, want true when source matches saved commit/version")
+	}
+	if got.LatestVersion != "" {
+		t.Errorf("LatestVersion = %q, want empty when up-to-date", got.LatestVersion)
+	}
+}
+
+func TestCheckLocalSource_SourceAdvanced(t *testing.T) {
+	dir, repo := initRepo(t)
+	base := addCommit(t, repo, dir, "base")
+	tagCommit(t, repo, "v1.0.0", base, false)
+
+	saved, err := pkggit.Describe(dir)
+	if err != nil {
+		t.Fatalf("Describe (saved): %v", err)
+	}
+
+	// Source moves forward after the template was saved.
+	addCommit(t, repo, dir, "second")
+	newDesc, err := pkggit.Describe(dir)
+	if err != nil {
+		t.Fatalf("Describe (new): %v", err)
+	}
+
+	got := pkggit.CheckLocalSource(dir, saved.Commit, saved.Version)
+	if got.ErrorKind != pkggit.CheckErrorNone {
+		t.Fatalf("ErrorKind = %q, want none", got.ErrorKind)
+	}
+	if got.IsUpToDate {
+		t.Errorf("IsUpToDate = true, want false when source advanced")
+	}
+	if got.LatestVersion != newDesc.Version {
+		t.Errorf("LatestVersion = %q, want %q (current source version)", got.LatestVersion, newDesc.Version)
+	}
+}
+
+func TestCheckLocalSource_ErrIsSourceMissing(t *testing.T) {
+	got := pkggit.CheckLocalSource(filepath.Join(t.TempDir(), "nope"), "abc", "v1.0.0")
+	if err := got.Err(); err != pkggit.ErrCheckSourceMissing {
+		t.Errorf("Err() = %v, want %v", err, pkggit.ErrCheckSourceMissing)
+	}
+}

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -279,11 +279,12 @@ func CurrentBranch(dir string) (string, error) {
 type CheckErrorKind string
 
 const (
-	CheckErrorNone     CheckErrorKind = ""
-	CheckErrorNetwork  CheckErrorKind = "network"
-	CheckErrorAuth     CheckErrorKind = "auth"
-	CheckErrorNotFound CheckErrorKind = "not-found"
-	CheckErrorUnknown  CheckErrorKind = "unknown"
+	CheckErrorNone          CheckErrorKind = ""
+	CheckErrorNetwork       CheckErrorKind = "network"
+	CheckErrorAuth          CheckErrorKind = "auth"
+	CheckErrorNotFound      CheckErrorKind = "not-found"
+	CheckErrorUnknown       CheckErrorKind = "unknown"
+	CheckErrorSourceMissing CheckErrorKind = "source-missing"
 )
 
 var (
@@ -295,6 +296,9 @@ var (
 	ErrCheckNotFound = errors.New("repository not found at remote")
 	// ErrCheckUnknown is returned when a remote status check fails for an unknown reason.
 	ErrCheckUnknown = errors.New("unknown error checking remote")
+	// ErrCheckSourceMissing is returned when a local template's source path no longer
+	// exists (or is no longer a git repository) so its status cannot be determined.
+	ErrCheckSourceMissing = errors.New("local source path is missing")
 )
 
 // RemoteCheckResult is the outcome of CheckRemote.
@@ -316,6 +320,8 @@ func (r RemoteCheckResult) Err() error {
 		return ErrCheckNotFound
 	case CheckErrorUnknown:
 		return ErrCheckUnknown
+	case CheckErrorSourceMissing:
+		return ErrCheckSourceMissing
 	default:
 		return nil
 	}
@@ -415,6 +421,44 @@ func semverTagAtCommit(repo *gogit.Repository, hash plumbing.Hash) string {
 // CheckRemote is a context-free convenience wrapper around CheckRemoteContext.
 func CheckRemote(dir, url, branch string) RemoteCheckResult {
 	return CheckRemoteContext(context.Background(), dir, url, branch)
+}
+
+// CheckLocalSource determines whether a template registered from a local path
+// (a "local:<path>" repository) is behind the current state of that path. Unlike
+// CheckRemoteContext, it never touches the network or the template's git origin —
+// the "source of truth" for a local template is the directory it was saved from.
+//
+// sourcePath is the on-disk path the template was saved from (the "local:" prefix
+// already stripped). savedCommit/savedVersion are the metadata recorded at save
+// time. The path's current git-describe output is compared against them:
+//
+//   - path missing or not a git repository → ErrorKind CheckErrorSourceMissing.
+//   - describe matches the saved commit and version → up-to-date.
+//   - otherwise → not up-to-date, with LatestVersion set to the path's current version.
+func CheckLocalSource(sourcePath, savedCommit, savedVersion string) (result RemoteCheckResult) {
+	slog.Debug("git check-local start", "source", sourcePath, "saved_commit", savedCommit, "saved_version", savedVersion)
+	defer func() {
+		slog.Debug("git check-local result",
+			"source", sourcePath,
+			"up_to_date", result.IsUpToDate,
+			"latest_version", result.LatestVersion,
+			"error_kind", string(result.ErrorKind),
+		)
+	}()
+
+	if info, err := os.Stat(sourcePath); err != nil || !info.IsDir() {
+		return RemoteCheckResult{ErrorKind: CheckErrorSourceMissing}
+	}
+
+	desc, err := Describe(sourcePath)
+	if err != nil {
+		return RemoteCheckResult{ErrorKind: CheckErrorSourceMissing}
+	}
+
+	if desc.Commit == savedCommit && desc.Version == savedVersion {
+		return RemoteCheckResult{IsUpToDate: true}
+	}
+	return RemoteCheckResult{IsUpToDate: false, LatestVersion: desc.Version}
 }
 
 // classifyRemoteError maps a remote.List error to a CheckErrorKind.


### PR DESCRIPTION
## Summary
- Check `local:` templates against their **source path on disk** (not the copied git origin), so `update available` reflects the source directory the template was saved from; adds a `source missing` status when that path is gone.
- Version-stamp `__status.json` and refresh it when written by a different `specs` version, so a status-check logic fix takes effect on the next `list` after an upgrade instead of waiting out the 24h staleness window.
- Upgrade local templates by re-copying from their source path (previously always skipped); missing source path errors as `ErrLocalSourceMissing`.
- Tests across `git`, `template`, `registry`, and `cmd`; docs + README updated.

## Notes
- The remote-template semver detection fix (#83) already landed in v0.0.11; this PR fixes the remaining stale-cache masking and the local-source case.